### PR TITLE
Support other onelogin regions

### DIFF
--- a/cmd/providers.go
+++ b/cmd/providers.go
@@ -15,6 +15,7 @@ var clientID string
 var clientSecret string
 var subdomain string
 var username string
+var region string
 
 // Okta
 var baseURL string
@@ -28,6 +29,9 @@ func init() {
 	cmdProvidersCreateOneLogin.Flags().StringVar(&subdomain, "subdomain", "", "OneLogin subdomain")
 	cmdProvidersCreateOneLogin.Flags().StringVar(&username, "username", "",
 		"Don't ask for a username and use this instead")
+	cmdProvidersCreateOneLogin.Flags().StringVar(&region, "region", "US",
+		"Region in which onelogin API lives")
+
 	cmdProvidersCreateOneLogin.MarkFlagRequired("client-id")
 	cmdProvidersCreateOneLogin.MarkFlagRequired("client-secret")
 	cmdProvidersCreateOneLogin.MarkFlagRequired("subdomain")
@@ -101,6 +105,7 @@ var cmdProvidersCreateOneLogin = &cobra.Command{
 			"subdomain":     subdomain,
 			"type":          "onelogin",
 			"username":      username,
+			"region":        region,
 		}
 		viper.Set(fmt.Sprintf("providers.%s", name), conf)
 

--- a/config/config.go
+++ b/config/config.go
@@ -14,6 +14,7 @@ type OneLoginProviderConfig struct {
 	Subdomain    string
 	Type         string
 	Username     string
+	Region       string
 }
 
 // GetOneLoginProvider returns a OneLoginProviderConfig struct containing the configuration for
@@ -22,7 +23,8 @@ func GetOneLoginProvider(p string) (*OneLoginProviderConfig, error) {
 	clientSecret := viper.GetString(fmt.Sprintf("providers.%s.client-secret", p))
 	clientID := viper.GetString(fmt.Sprintf("providers.%s.client-id", p))
 	subdomain := viper.GetString(fmt.Sprintf("providers.%s.subdomain", p))
-	user := viper.GetString(fmt.Sprintf("providers.%s.username", p))
+	username := viper.GetString(fmt.Sprintf("providers.%s.username", p))
+	region := viper.GetString(fmt.Sprintf("providers.%s.region", p))
 
 	if clientSecret == "" {
 		return nil, errors.New("client-secret config value must bet set")
@@ -34,11 +36,16 @@ func GetOneLoginProvider(p string) (*OneLoginProviderConfig, error) {
 		return nil, errors.New("subdomain config value must bet set")
 	}
 
+	if region == "" {
+		region = "US"
+	}
+
 	c := OneLoginProviderConfig{
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
 		Subdomain:    subdomain,
-		Username:     user,
+		Username:     username,
+		Region:       region,
 	}
 
 	return &c, nil

--- a/onelogin/client.go
+++ b/onelogin/client.go
@@ -10,22 +10,6 @@ import (
 	"time"
 )
 
-// TODO Add support for eu.onelogin.com
-const (
-	GenerateTokensURL        string = "https://api.us.onelogin.com/auth/oauth2/token"
-	GenerateSamlAssertionURL string = "https://api.us.onelogin.com/api/1/saml_assertion"
-	GetUserByEmailURL        string = "https://api.us.onelogin.com/api/1/users?email=%s"
-	VerifyFactorURL          string = "https://api.us.onelogin.com/api/1/saml_assertion/verify_factor"
-)
-
-// Endpoints represent the OneLogin API HTTP endpoints.
-type Endpoints struct {
-	GenerateSamlAssertion string
-	GenerateTokens        string
-	GetUserByEmail        string
-	VerifyFactor          string
-}
-
 // Client represents a OneLogin API client.
 type Client struct {
 	http.Client
@@ -163,7 +147,7 @@ func (c *Client) GenerateTokens(clientID, clientSecret string) (string, error) {
 	}
 	body := GenerateTokensParams{GrantType: "client_credentials"}
 
-	req, err := makeRequest(http.MethodPost, c.Endpoints.GenerateTokens, headers, &body)
+	req, err := makeRequest(http.MethodPost, c.Endpoints.GenerateTokens(), headers, &body)
 	if err != nil {
 		return "", fmt.Errorf("creating request: %v", err)
 	}
@@ -193,7 +177,7 @@ func (c *Client) GenerateSamlAssertion(token string, p *GenerateSamlAssertionPar
 	}
 	body := p
 
-	req, err := makeRequest(http.MethodPost, c.Endpoints.GenerateSamlAssertion, headers, &body)
+	req, err := makeRequest(http.MethodPost, c.Endpoints.GenerateSamlAssertion(), headers, &body)
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %v", err)
 	}
@@ -225,7 +209,7 @@ func (c *Client) VerifyFactor(token string, p *VerifyFactorParams) (*VerifyFacto
 	}
 	body := p
 
-	req, err := makeRequest(http.MethodPost, c.Endpoints.VerifyFactor, headers, &body)
+	req, err := makeRequest(http.MethodPost, c.Endpoints.VerifyFactor(), headers, &body)
 	if err != nil {
 		// TODO Let the user know which method generated the error
 		return nil, fmt.Errorf("creating request: %v", err)
@@ -245,13 +229,9 @@ func (c *Client) VerifyFactor(token string, p *VerifyFactorParams) (*VerifyFacto
 }
 
 // NewClient creates a new Client and returns a pointer to it.
-func NewClient() *Client {
-	return &Client{
-		Endpoints: Endpoints{
-			GenerateSamlAssertion: GenerateSamlAssertionURL,
-			GenerateTokens:        GenerateTokensURL,
-			GetUserByEmail:        GetUserByEmailURL,
-			VerifyFactor:          VerifyFactorURL,
-		},
-	}
+func NewClient(region string) (c *Client, err error) {
+	c.Endpoints = Endpoints{Region: region}
+	err = c.Endpoints.setBase()
+
+	return
 }

--- a/onelogin/client_test.go
+++ b/onelogin/client_test.go
@@ -3,6 +3,7 @@ package onelogin
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 )
 
@@ -39,7 +40,7 @@ func TestGenerateTokens(t *testing.T) {
 	ts := getTestServer(data)
 	defer ts.Close()
 
-	c.Endpoints.GenerateTokens = ts.URL
+	c.Endpoints.base, _ = url.Parse(ts.URL)
 
 	resp, err := c.GenerateTokens("test", "test")
 	if err != nil {
@@ -81,7 +82,7 @@ func TestGenerateSamlAssertion(t *testing.T) {
 	ts := getTestServer(data)
 	defer ts.Close()
 
-	c.Endpoints.GenerateSamlAssertion = ts.URL
+	c.Endpoints.base, _ = url.Parse(ts.URL)
 
 	p := GenerateSamlAssertionParams{
 		UsernameOrEmail: "test",
@@ -116,7 +117,7 @@ func TestVerifyFactor(t *testing.T) {
 	ts := getTestServer(data)
 	defer ts.Close()
 
-	c.Endpoints.VerifyFactor = ts.URL
+	c.Endpoints.base, _ = url.Parse(ts.URL)
 
 	p := VerifyFactorParams{
 		AppId:      "test",

--- a/onelogin/endpoints.go
+++ b/onelogin/endpoints.go
@@ -1,0 +1,75 @@
+package onelogin
+
+import (
+	"fmt"
+	"net/url"
+)
+
+const (
+	usBase = "https://api.us.onelogin.com"
+	euBase = "https://api.eu.onelogin.com"
+
+	GenerateSamlAssertionPath string = "/api/1/saml_assertion"
+	GenerateTokensPath        string = "/auth/oauth2/token"
+	GetUserByEmailPath        string = "/api/1/users?email=%s"
+	VerifyFactorPath          string = "/api/1/saml_assertion/verify_factor"
+)
+
+// Endpoints represent the OneLogin API HTTP endpoints.
+type Endpoints struct {
+	Region string
+
+	base *url.URL
+}
+
+func (e *Endpoints) setBase() (err error) {
+	var base string
+	switch e.Region {
+	case "US":
+		base = usBase
+
+	case "EU":
+		base = euBase
+
+	default:
+		return fmt.Errorf("Region %q is an invalid onelogin region. Valid values are EU or US", e.Region)
+	}
+
+	e.base, err = url.Parse(base)
+
+	return
+}
+
+// GenerateSamlAssertion will return a the relevant Generate SAML Assertion
+// endpoint for a given base URL
+func (e Endpoints) GenerateSamlAssertion() string {
+	return e.doURL(GenerateSamlAssertionPath, make(url.Values))
+}
+
+// GenerateTokens will return the relevant Generate Tokens endpoint
+// for a base URL
+func (e Endpoints) GenerateTokens() string {
+	return e.doURL(GenerateTokensPath, make(url.Values))
+}
+
+// GetUserByEmail will, given an email address, return a valid url
+// to search the Users endpoint by email address
+func (e Endpoints) GetUserByEmail(email string) string {
+	return e.doURL(GetUserByEmailPath, url.Values{"email": []string{email}})
+}
+
+// VerifyFactor will return a valid URL for requests to check MFA tokens
+func (e Endpoints) VerifyFactor() string {
+	return e.doURL(VerifyFactorPath, make(url.Values))
+}
+
+func (e Endpoints) doURL(endpoint string, params url.Values) string {
+	if e.base == nil {
+		return ""
+	}
+
+	e.base.Path = endpoint
+	e.base.RawQuery = params.Encode()
+
+	return e.base.String()
+}

--- a/onelogin/endpoints_test.go
+++ b/onelogin/endpoints_test.go
@@ -1,0 +1,59 @@
+package onelogin
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestEndpoints_SetBase(t *testing.T) {
+	for _, test := range []struct {
+		name             string
+		region           string
+		expectVerifyPath string
+		expectError      bool
+	}{
+		{"Region US", "US", "https://api.us.onelogin.com/api/1/saml_assertion/verify_factor", false},
+		{"Region EU", "EU", "https://api.eu.onelogin.com/api/1/saml_assertion/verify_factor", false},
+		{"No such region", "no such", "", true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			e := Endpoints{Region: test.region}
+
+			err := e.setBase()
+			if test.expectError && err == nil {
+				t.Errorf("expected error")
+			}
+
+			if !test.expectError && err != nil {
+				t.Errorf("unexpected error %+v", err)
+			}
+
+			if test.expectVerifyPath != e.VerifyFactor() {
+				t.Errorf("expected %q, received %q", test.expectVerifyPath, e.VerifyFactor())
+			}
+
+		})
+	}
+}
+
+func TestEndpoints_GetUserByEmail(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		baseURL string
+		email   string
+		expect  string
+	}{
+		{"Happy path", "http://example.com", "root@example.com", "http://example.com/api/1/users%3Femail=%25s?email=root%40example.com"},
+		{"Empty email", "http://example.com", "", "http://example.com/api/1/users%3Femail=%25s?email="},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			e := Endpoints{}
+			e.base, _ = url.Parse(test.baseURL)
+
+			u := e.GetUserByEmail(test.email)
+			if test.expect != u {
+				t.Errorf("expected %q, received %q", test.expect, u)
+			}
+		})
+	}
+}

--- a/onelogin/get.go
+++ b/onelogin/get.go
@@ -41,7 +41,10 @@ func Get(app, provider string) (*awsprovider.Credentials, error) {
 		return nil, fmt.Errorf("reading config for app %s: %v", app, err)
 	}
 
-	c := NewClient()
+	c, err := NewClient(p.Region)
+	if err != nil {
+		return nil, err
+	}
 
 	// Initialize spinner
 	var s SpinnerWrapper


### PR DESCRIPTION
The tool, currently, doesn't support onelogin EU- this PR adds that support.

It does this by taking an optional onelogin region (which defaults to US, should it not exist, for backwards compatibility) and then using this to form URLs.

The new code has 100% code coverage, including happy and unhappy path cases.

The README also reflects the change to the create provider call to include a onelogin region.