### PR TITLE
Store credentials in the system keychain

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -94,6 +94,14 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:30ab9deaf9ab00ba3e5ff2ea6dbedc83720b1563e311a05d2605dd62aa4fdc3f"
+  name = "github.com/guelfey/go.dbus"
+  packages = ["."]
+  pruneopts = ""
+  revision = "f6a3a2366cc39b8479cadc499d3c735fb10fbdda"
+
+[[projects]]
+  branch = "master"
   digest = "1:147d671753effde6d3bcd58fc74c1d67d740196c84c280c762a5417319499972"
   name = "github.com/hashicorp/hcl"
   packages = [
@@ -235,6 +243,14 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:477097b49b467b18aabe6dd53c5ec6d262723d9880ddade6fe5200200b2e6827"
+  name = "github.com/tmc/keyring"
+  packages = ["."]
+  pruneopts = ""
+  revision = "839169085ae146fc7a34bcb34dfd7ab216d23991"
+
+[[projects]]
+  branch = "master"
   digest = "1:9171fe485c166e2d78471fabe2fb3497290552201127058205c3132edd71f7eb"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
@@ -313,6 +329,7 @@
     "github.com/mitchellh/go-homedir",
     "github.com/spf13/cobra",
     "github.com/spf13/viper",
+    "github.com/tmc/keyring",
     "golang.org/x/net/publicsuffix",
   ]
   solver-name = "gps-cdcl"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -56,3 +56,7 @@
 [[constraint]]
   name = "github.com/mattn/go-colorable"
   version = "0.0.9"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/tmc/keyring"

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -92,15 +92,9 @@ func getOneLogin(app string) {
 	if savePassword {
 		// User asked to save a new password - don't check keychain
 		fmt.Print("OneLogin password: ")
-		pass, err := gopass.GetPasswd()
+		pass, err = gopass.GetPasswd()
 		if err != nil {
 			log.Fatalf(color.RedString("Error reading password from terminal: %v"), err)
-		}
-
-		// Save password in keychain
-		err = keyChain.Set(provider, pass)
-		if err != nil {
-			fmt.Printf("Could not save password to keychain: %v", err)
 		}
 	} else {
 		// Check if we have a saved password
@@ -119,10 +113,21 @@ func getOneLogin(app string) {
 	if err != nil {
 		log.Fatal(color.RedString("Could not get temporary credentials: "), err)
 	}
+
 	// Process credentials
 	err = processCredentials(creds, app)
 	if err != nil {
 		log.Fatalf(color.RedString("Error processing credentials: %v"), err)
+	}
+
+	// Save password in keychain (following a successful authentication)
+	if savePassword {
+		err = keyChain.Set(provider, pass)
+		if err != nil {
+			log.Printf(color.RedString("Could not save password to keychain: %v"), err)
+			return
+		}
+		log.Println(color.GreenString("Password saved successfully in keychain"))
 	}
 }
 
@@ -151,15 +156,9 @@ func getOkta(app string) {
 	if savePassword {
 		// User asked to save a new password - don't check keychain
 		fmt.Print("Okta password: ")
-		pass, err := gopass.GetPasswd()
+		pass, err = gopass.GetPasswd()
 		if err != nil {
 			log.Fatalf(color.RedString("Error reading password from terminal: %v"), err)
-		}
-
-		// Save password in keychain
-		err = keyChain.Set(provider, pass)
-		if err != nil {
-			fmt.Printf("Could not save password to keychain: %v", err)
 		}
 	} else {
 		// Check if we have a saved password
@@ -178,10 +177,21 @@ func getOkta(app string) {
 	if err != nil {
 		log.Fatal(color.RedString("Could not get temporary credentials: "), err)
 	}
+
 	// Process credentials
 	err = processCredentials(creds, app)
 	if err != nil {
 		log.Fatalf(color.RedString("Error processing credentials: %v"), err)
+	}
+
+	// Save password in keychain (following a successful authentication)
+	if savePassword {
+		err = keyChain.Set(provider, pass)
+		if err != nil {
+			log.Printf(color.RedString("Could not save password to keychain: %v"), err)
+			return
+		}
+		log.Println(color.GreenString("Password saved successfully in keychain"))
 	}
 }
 

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -68,7 +68,7 @@ func processCredentials(creds *aws.Credentials, app string) error {
 }
 
 // getOneLogin get temporary credentials for an app of type OneLogin.
-func getOneLogin(app string) {
+func getOneLogin(app, provider string) {
 	// Read app config
 	aConfig, err := config.GetOneLoginApp(app)
 	if err != nil {
@@ -76,7 +76,7 @@ func getOneLogin(app string) {
 	}
 
 	// Read provider config
-	pConfig, err := config.GetOneLoginProvider(aConfig.Provider)
+	pConfig, err := config.GetOneLoginProvider(provider)
 	if err != nil {
 		log.Fatalf(color.RedString("Error reading provider config: %v"), err)
 	}
@@ -132,7 +132,7 @@ func getOneLogin(app string) {
 }
 
 // getOkta get temporary credentials for an app of type Okta.
-func getOkta(app string) {
+func getOkta(app, provider string) {
 	// Read app config
 	aConfig, err := config.GetOktaApp(app)
 	if err != nil {
@@ -140,7 +140,7 @@ func getOkta(app string) {
 	}
 
 	// Read provider config
-	pConfig, err := config.GetOktaProvider(aConfig.Provider)
+	pConfig, err := config.GetOktaProvider(provider)
 	if err != nil {
 		log.Fatalf(color.RedString("Error reading provider config: %v"), err)
 	}
@@ -230,9 +230,9 @@ If no app is specified, the selected app (if configured) will be assumed.`,
 
 		switch pType {
 		case ProviderOneLogin:
-			getOneLogin(app)
+			getOneLogin(app, provider)
 		case ProviderOkta:
-			getOkta(app)
+			getOkta(app, provider)
 		default:
 			log.Fatalf(color.RedString("Unsupported identity provider type '%s' for app '%s'"), pType, app)
 		}

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -26,6 +26,8 @@ const (
 	ProviderOkta = "okta"
 )
 
+var keyChain = keychain.DefaultKeychain{}
+
 var printToShell bool
 var writeToFile string
 var savePassword bool
@@ -86,8 +88,6 @@ func getOneLogin(app string) {
 		fmt.Scanln(&user)
 	}
 
-	keyChain := keychain.DefaultKeychain{}
-
 	var pass []byte
 	if savePassword {
 		// User asked to save a new password - don't check keychain
@@ -146,8 +146,6 @@ func getOkta(app string) {
 		fmt.Print("Okta username: ")
 		fmt.Scanln(&user)
 	}
-
-	keyChain := keychain.DefaultKeychain{}
 
 	var pass []byte
 	if savePassword {

--- a/config/config.go
+++ b/config/config.go
@@ -7,8 +7,8 @@ import (
 	"github.com/spf13/viper"
 )
 
-// OneLoginProviderConfig represents a OneLogin provider configuration.
-type OneLoginProviderConfig struct {
+// OneLoginProvider represents a OneLogin provider configuration.
+type OneLoginProvider struct {
 	ClientID     string
 	ClientSecret string
 	Subdomain    string
@@ -19,7 +19,7 @@ type OneLoginProviderConfig struct {
 
 // GetOneLoginProvider returns a OneLoginProviderConfig struct containing the configuration for
 // provider p.
-func GetOneLoginProvider(p string) (*OneLoginProviderConfig, error) {
+func GetOneLoginProvider(p string) (*OneLoginProvider, error) {
 	clientSecret := viper.GetString(fmt.Sprintf("providers.%s.client-secret", p))
 	clientID := viper.GetString(fmt.Sprintf("providers.%s.client-id", p))
 	subdomain := viper.GetString(fmt.Sprintf("providers.%s.subdomain", p))
@@ -40,7 +40,7 @@ func GetOneLoginProvider(p string) (*OneLoginProviderConfig, error) {
 		region = "US"
 	}
 
-	c := OneLoginProviderConfig{
+	c := OneLoginProvider{
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
 		Subdomain:    subdomain,
@@ -51,14 +51,14 @@ func GetOneLoginProvider(p string) (*OneLoginProviderConfig, error) {
 	return &c, nil
 }
 
-// OneLoginAppConfig represents a OneLogin app configuration.
-type OneLoginAppConfig struct {
+// OneLoginApp represents a OneLogin app configuration.
+type OneLoginApp struct {
 	ID       string
 	Provider string
 }
 
-// GetOneLoginApp returns a OneLoginAppConfig struct containing the configuration for app.
-func GetOneLoginApp(app string) (*OneLoginAppConfig, error) {
+// GetOneLoginApp returns a OneLoginApp struct containing the configuration for app.
+func GetOneLoginApp(app string) (*OneLoginApp, error) {
 	config := viper.GetStringMapString("apps." + app)
 	appID := config["app-id"]
 	provider := config["provider"]
@@ -67,7 +67,7 @@ func GetOneLoginApp(app string) (*OneLoginAppConfig, error) {
 		return nil, errors.New("app-id config value must be set")
 	}
 
-	c := OneLoginAppConfig{
+	c := OneLoginApp{
 		ID:       appID,
 		Provider: provider,
 	}
@@ -75,14 +75,14 @@ func GetOneLoginApp(app string) (*OneLoginAppConfig, error) {
 	return &c, nil
 }
 
-// OktaProviderConfig represents an Okta provider configuration.
-type OktaProviderConfig struct {
+// OktaProvider represents an Okta provider configuration.
+type OktaProvider struct {
 	BaseURL  string
 	Username string
 }
 
-// GetOktaProvider returns a OktaProviderConfig struct containing the configuration for provider p.
-func GetOktaProvider(p string) (*OktaProviderConfig, error) {
+// GetOktaProvider returns a OktaProvider struct containing the configuration for provider p.
+func GetOktaProvider(p string) (*OktaProvider, error) {
 	baseURL := viper.GetString(fmt.Sprintf("providers.%s.base-url", p))
 	username := viper.GetString(fmt.Sprintf("providers.%s.username", p))
 
@@ -90,17 +90,17 @@ func GetOktaProvider(p string) (*OktaProviderConfig, error) {
 		return nil, errors.New("base-url config value must bet set")
 	}
 
-	return &OktaProviderConfig{BaseURL: baseURL, Username: username}, nil
+	return &OktaProvider{BaseURL: baseURL, Username: username}, nil
 }
 
-// OktaAppConfig represents an Okta app configuration.
-type OktaAppConfig struct {
+// OktaApp represents an Okta app configuration.
+type OktaApp struct {
 	Provider string
 	URL      string
 }
 
-// GetOktaApp returns an OktaAppConfig struct containing the configuration for app.
-func GetOktaApp(app string) (*OktaAppConfig, error) {
+// GetOktaApp returns an OktaApp struct containing the configuration for app.
+func GetOktaApp(app string) (*OktaApp, error) {
 	config := viper.GetStringMapString("apps." + app)
 
 	provider := config["provider"]
@@ -114,7 +114,7 @@ func GetOktaApp(app string) (*OktaAppConfig, error) {
 		return nil, errors.New("url config value must be set")
 	}
 
-	return &OktaAppConfig{
+	return &OktaApp{
 		Provider: provider,
 		URL:      url,
 	}, nil

--- a/keychain/keychain.go
+++ b/keychain/keychain.go
@@ -1,0 +1,37 @@
+package keychain
+
+import (
+	"github.com/tmc/keyring"
+)
+
+const (
+	// KeyChainName is the name of the keychain used to store
+	// passwords
+	KeyChainName = "clisso"
+)
+
+// keychain provides an interface to allow for the easy testing
+// of this package
+type Keychain interface {
+	Get(string) ([]byte, error)
+	Set(string, []byte) error
+}
+
+// DefaultKeyChain provides a wrapper around github.com/tmc/keyring
+// and provides defaults and abstractions for clisso to get passwords
+type DefaultKeychain struct{}
+
+// Set takes a provider in an argument, and a password from STDIN, and
+// sets it in a keychain, should one exist.
+func (DefaultKeychain) Set(provider string, password []byte) (err error) {
+	return keyring.Set(KeyChainName, provider, string(password))
+}
+
+// Get will, once given a valid provider, return the password associated
+// in order for logins to happen
+func (DefaultKeychain) Get(provider string) (pw []byte, err error) {
+	pwString, err := keyring.Get(KeyChainName, provider)
+	pw = []byte(pwString)
+
+	return
+}

--- a/keychain/keychain.go
+++ b/keychain/keychain.go
@@ -5,30 +5,26 @@ import (
 )
 
 const (
-	// KeyChainName is the name of the keychain used to store
-	// passwords
+	// KeyChainName is the name of the keychain used by Clisso to store passwords.
 	KeyChainName = "clisso"
 )
 
-// keychain provides an interface to allow for the easy testing
-// of this package
+// Keychain provides an interface to allow for easy testing.
 type Keychain interface {
 	Get(string) ([]byte, error)
 	Set(string, []byte) error
 }
 
-// DefaultKeyChain provides a wrapper around github.com/tmc/keyring
-// and provides defaults and abstractions for clisso to get passwords
+// DefaultKeychain provides a wrapper around github.com/tmc/keyring as well as defaults and
+// abstractions for Clisso.
 type DefaultKeychain struct{}
 
-// Set takes a provider in an argument, and a password from STDIN, and
-// sets it in a keychain, should one exist.
+// Set stores the given password for the given provider in a keychain.
 func (DefaultKeychain) Set(provider string, password []byte) (err error) {
 	return keyring.Set(KeyChainName, provider, string(password))
 }
 
-// Get will, once given a valid provider, return the password associated
-// in order for logins to happen
+// Get returns the stored password for the given provider, or an error.
 func (DefaultKeychain) Get(provider string) (pw []byte, err error) {
 	pwString, err := keyring.Get(KeyChainName, provider)
 	pw = []byte(pwString)

--- a/okta/get.go
+++ b/okta/get.go
@@ -11,7 +11,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts"
-	"github.com/howeyc/gopass"
 )
 
 var (
@@ -19,47 +18,11 @@ var (
 )
 
 // Get gets temporary credentials for the given app.
-func Get(app, provider string) (*awsprovider.Credentials, error) {
-	// Get provider config
-	p, err := config.GetOktaProvider(provider)
-	if err != nil {
-		return nil, fmt.Errorf("reading provider config: %v", err)
-	}
-
-	// Get app config
-	a, err := config.GetOktaApp(app)
-	if err != nil {
-		return nil, fmt.Errorf("reading config for app %s: %v", app, err)
-	}
-
+func Get(a *config.OktaApp, p *config.OktaProvider, user string, pass string) (*awsprovider.Credentials, error) {
 	// Initialize Okta client
 	c, err := NewClient(p.BaseURL)
 	if err != nil {
 		return nil, fmt.Errorf("initializing Okta client: %v", err)
-	}
-
-	// Get user credentials
-	user := p.Username
-	if user == "" {
-		// Get credentials from the user
-		fmt.Print("Okta username: ")
-		fmt.Scanln(&user)
-	}
-
-	pass, err := keyChain.Get(provider)
-	if err != nil {
-		fmt.Printf("Could not get password from keychain,\n\t%s\n", err.Error())
-
-		fmt.Print("Please enter Okta password: ")
-		pass, err := gopass.GetPasswd()
-		if err != nil {
-			return nil, fmt.Errorf("Couldn't read password from terminal")
-		}
-
-		err = keyChain.Set(provider, pass)
-		if err != nil {
-			fmt.Printf("Could not save to keychain: %+v", err)
-		}
 	}
 
 	// Initialize spinner

--- a/okta/get.go
+++ b/okta/get.go
@@ -5,12 +5,17 @@ import (
 
 	awsprovider "github.com/allcloud-io/clisso/aws"
 	"github.com/allcloud-io/clisso/config"
+	"github.com/allcloud-io/clisso/keychain"
 	"github.com/allcloud-io/clisso/saml"
 	"github.com/allcloud-io/clisso/spinner"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/howeyc/gopass"
+)
+
+var (
+	keyChain = keychain.DefaultKeychain{}
 )
 
 // Get gets temporary credentials for the given app.
@@ -41,10 +46,20 @@ func Get(app, provider string) (*awsprovider.Credentials, error) {
 		fmt.Scanln(&user)
 	}
 
-	fmt.Print("Okta password: ")
-	pass, err := gopass.GetPasswd()
+	pass, err := keyChain.Get(provider)
 	if err != nil {
-		return nil, fmt.Errorf("Couldn't read password from terminal")
+		fmt.Printf("Could not get password from keychain,\n\t%s\n", err.Error())
+
+		fmt.Print("Please enter Okta password: ")
+		pass, err := gopass.GetPasswd()
+		if err != nil {
+			return nil, fmt.Errorf("Couldn't read password from terminal")
+		}
+
+		err = keyChain.Set(provider, pass)
+		if err != nil {
+			fmt.Printf("Could not save to keychain: %+v", err)
+		}
 	}
 
 	// Initialize spinner

--- a/onelogin/get.go
+++ b/onelogin/get.go
@@ -29,9 +29,10 @@ const (
 // Get gets temporary credentials for the given app.
 // TODO Move AWS logic outside this function.
 func Get(a *config.OneLoginApp, p *config.OneLoginProvider, user string, pass string) (*awsprovider.Credentials, error) {
+	// Initialize OneLogin client
 	c, err := NewClient(p.Region)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("initializing OneLogin client: %v", err)
 	}
 
 	// Initialize spinner


### PR DESCRIPTION
This PR will allow for passwords to be stored in system keychains, as per https://github.com/allcloud-io/clisso/issues/50

Given the config:

```yaml
apps:
  foo:
    app-id: "123"
    principal-arn: asaa
    provider: my-provider
    role-arn: sss
global:
  credentials-path: /tmp/.aws/credentials
  selected-app: foo
providers:
  my-provider:
    client-id: id
    client-secret: secret
    subdomain: example
    type: onelogin
    username: user@example.com
```

Running `clisso get` twice (ignoring the 401s from my dummy config):

```bash
$(keychain_support) ./clisso get
Could not get password from keychain,
        keyring: Password not found
Please enter OneLogin password: 
Could not get temporary credentials: generating SAML assertion: doing HTTP request: 400 Bad Request

$(keychain_support) ./clisso get
Could not get temporary credentials: generating SAML assertion: doing HTTP request: 401 Unauthorized
```

## Note

The keyring is abstracted away a bit in this PR. This is to allow for the stubbing out of keyrings when later writing tests for `Get` functions- something that isn't done at the moment.