### PR TITLE
Feature/max session duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,10 +146,10 @@ Clisso prompt for a username every time.
 
 The `--duration` flag is optional. If specified, sessions will be assumed with the provided
 duration, in seconds, instead of the default of 14400 (4 hours). Valid values are between 3600 and
-43200 seconds. The max session duration has to be configured on the role in AWS. If a longer
-session time is requested than what is configured on the AWS role, Clisso will provide the `awscli`
-command to change it. The default duration specified on provider level can be overridden on a per
-app level (see below).
+43200 seconds. The [max session duration](12) has be equal to or lower than what is configured on
+the role in AWS. If a longer session time is requested than what is configured on the AWS role,
+Clisso will lower the duration and retry. The default duration specified on provider level can be
+overridden on a per app level (see below).
 
 #### Okta
 
@@ -175,10 +175,11 @@ Clisso prompt for a username every time.
 
 The `--duration` flag is optional. If specified, sessions will be assumed with the provided
 duration, in seconds, instead of the default of 14400 (4 hours). Valid values are between 3600 and
-43200 seconds. The max session duration has to be configured on the role in AWS. If a longer
-session time is requested than what is configured on the AWS role, Clisso will provide the `awscli`
-command to change it. The default duration specified on provider level can be overridden on a per
-app level (see below).
+43200 seconds. The [max session duration](12) has be equal to or lower than what is configured on
+the role in AWS. If a longer session time is requested than what is configured on the AWS role,
+Clisso will lower the duration and retry. The default duration specified on provider level can be
+overridden on a per app level (see below).
+
 ### Deleting Providers
 
 Deleting providers using the `clisso` command isn't currently supported. To delete a provider,
@@ -209,9 +210,10 @@ manually configure the app ID for every app.
 
 The `--duration` flag is optional and defaults to the value set at the provider level. Valid values
 are between 3600 and 43200 seconds. Can be used to raise or lower the session duration for an
-individual app, depending on the security needs for the specific app. The value used here has to
-match the max session duration configured on the AWS role; the default maximum is 3600 seconds. If
-a mismatch is detected Clisso will provide the `awscli` command to change it.
+individual app, depending on the security needs for the specific app. The [max session duration](12)
+has be equal to or lower than what is configured on the role in AWS. The default maximum is 3600
+seconds. If a mismatch is detected Clisso will try to assume the role with a lower duration than
+requested.
 
 #### Okta
 
@@ -235,9 +237,10 @@ should end with `/137`.
 
 The `--duration` flag is optional and defaults to the value set at the provider level. Valid values
 are between 3600 and 43200 seconds. Can be used to raise or lower the session duration for an
-individual app, depending on the security needs for the specific app. The value used here has to
-match the max session duration configured on the AWS role; the default maximum is 3600 seconds. If
-a mismatch is detected Clisso will provide the `awscli` command to change it.
+individual app, depending on the security needs for the specific app. The [max session duration](12)
+has be equal to or lower than what is configured on the role in AWS. The default maximum is 3600
+seconds. If a mismatch is detected Clisso will try to assume the role with a lower duration than
+requested.
 
 ### Deleting Apps
 
@@ -293,3 +296,4 @@ TODO
 [9]: https://onelogin.service-now.com/support?id=kb_article&sys_id=de999903db109700d5505eea4b961966
 [10]: https://docs.aws.amazon.com/cli/latest/userguide/cli-multiple-profiles.html
 [11]: sample_config.yaml
+[12]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html#id_roles_use_view-role-max-session

--- a/README.md
+++ b/README.md
@@ -144,10 +144,9 @@ The `--username` flag is optional, and allows Clisso to always use the given val
 username when retrieving credentials for apps which use this provider. Omitting this flag will make
 Clisso prompt for a username every time.
 
-The `--duration` flag is optional. If specified sessions will be assumed with this duration instead
-of the default 14400 seconds (4h). Valid values are between 3600 and 43200 seconds. Has to be
-configured on the role in AWS, too. If a mismatch is detected clisso will provide the `awscli`
-command-line to change it. Can be overwritten on a app level (see below).
+The `--duration` flag is optional. If specified, sessions will be assumed with the provided duration, in seconds, instead of the default of 14400 (4 hours). Valid values are between 3600 and 43200 seconds. The max session duration has to be
+configured on the role in AWS. If a longer session time is requested than what is configured on the AWS role, Clisso will provide the `awscli`
+command to change it. The default duration specified on provider level can be overridden on a per app level (see below).
 
 #### Okta
 
@@ -171,10 +170,9 @@ The `--username` flag is optional, and allows Clisso to always use the given val
 username when retrieving credentials for apps which use this provider. Omitting this flag will make
 Clisso prompt for a username every time.
 
-The `--duration` flag is optional. If specified sessions will be assumed with this duration instead
-of the default 14400 seconds (4h). Valid values are between 3600 and 43200 seconds. Has to be
-configured on the role in AWS, too. If a mismatch is detected clisso will provide the `awscli`
-command-line to change it. Can be overwritten on a app level (see below).
+The `--duration` flag is optional. If specified, sessions will be assumed with the provided duration, in seconds, instead of the default of 14400 (4 hours). Valid values are between 3600 and 43200 seconds. The max session duration has to be
+configured on the role in AWS. If a longer session time is requested than what is configured on the AWS role, Clisso will provide the `awscli`
+command to change it. The default duration specified on provider level can be overridden on a per app level (see below).
 
 ### Deleting Providers
 
@@ -204,11 +202,10 @@ manually configure the app ID for every app.
 >NOTE: The ID seen in the browser URL when visiting a OneLogin app as a user is **NOT** the app ID.
 >Only a OneLogin administrator can obtain an app ID.
 
-The `--duration` flag is optional, defaults to the value set at the provider level. Valid values are
-between 3600 and 43200 seconds. Can be used to raise or lower the session duration on a per app basis,
-depending on the security needs for the specific app. Has to be configured on the role in AWS as the
-default maximum is 3600 seconds. If a mismatch is detected clisso will provide the `awscli`
-command-line to change it.
+The `--duration` flag is optional and defaults to the value set at the provider level. Valid values are
+between 3600 and 43200 seconds. Can be used to raise or lower the session duration for an individual app,
+depending on the security needs for the specific app. The value used here has to match the max session duration configured on the AWS role; the default maximum is 3600 seconds. If a mismatch is detected Clisso will provide the `awscli`
+command to change it.
 
 #### Okta
 
@@ -230,11 +227,10 @@ clicking an app in the **Applications** view. The embed link is on the **General
 >NOTE: An Okta embed link must not contain an HTTP query, only the base URL. For AWS apps, the link
 should end with `/137`.
 
-The `--duration` flag is optional, defaults to the value set at the provider level. Valid values are
-between 3600 and 43200 seconds. Can be used to raise or lower the session duration on a per app basis,
-depending on the security needs for the specific app. Has to be configured on the role in AWS as the
-default maximum is 3600 seconds. If a mismatch is detected clisso will provide the `awscli`
-command-line to change it.
+The `--duration` flag is optional and defaults to the value set at the provider level. Valid values are
+between 3600 and 43200 seconds. Can be used to raise or lower the session duration for an individual app,
+depending on the security needs for the specific app. The value used here has to match the max session duration configured on the AWS role; the default maximum is 3600 seconds. If a mismatch is detected Clisso will provide the `awscli`
+command to change it.
 
 ### Deleting Apps
 

--- a/README.md
+++ b/README.md
@@ -212,8 +212,8 @@ The `--duration` flag is optional and defaults to the value set at the provider 
 are between 3600 and 43200 seconds. Can be used to raise or lower the session duration for an
 individual app, depending on the security needs for the specific app. The [max session duration](12)
 has be equal to or lower than what is configured on the role in AWS. The default maximum is 3600
-seconds. If a mismatch is detected Clisso will try to assume the role with a lower duration than
-requested.
+seconds. If a mismatch is detected Clisso will try to assume the role with a duration of 3600
+seconds.
 
 #### Okta
 
@@ -239,8 +239,8 @@ The `--duration` flag is optional and defaults to the value set at the provider 
 are between 3600 and 43200 seconds. Can be used to raise or lower the session duration for an
 individual app, depending on the security needs for the specific app. The [max session duration](12)
 has be equal to or lower than what is configured on the role in AWS. The default maximum is 3600
-seconds. If a mismatch is detected Clisso will try to assume the role with a lower duration than
-requested.
+seconds. If a mismatch is detected Clisso will try to assume the role with a duration of 3600
+seconds.
 
 ### Deleting Apps
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,8 @@ To create a OneLogin identity provider, use the following command:
         --client-secret mysecret \
         --subdomain mycompany \
         --username user@mycompany.com \
-        --region US
+        --region US \
+        --duration 14400
 
 The example above creates a OneLogin identity provider configuration for Clisso, with the name
 `my-provider`.
@@ -143,13 +144,19 @@ The `--username` flag is optional, and allows Clisso to always use the given val
 username when retrieving credentials for apps which use this provider. Omitting this flag will make
 Clisso prompt for a username every time.
 
+The `--duration` flag is optional. If specified sessions will be assumed with this duration instead
+of the default 14400 seconds (4h). Valid values are between 3600 and 43200 seconds. Has to be
+configured on the role in AWS, too. If a mismatch is detected clisso will provide the `awscli`
+command-line to change it. Can be overwritten on a app level (see below).
+
 #### Okta
 
 To create an Okta identity provider, use the following command:
 
     clisso providers create okta my-provider \
         --base-url https://mycompany.okta.com \
-        --username user@mycompany.com
+        --username user@mycompany.com \
+        --duration 14400
 
 The example above creates an Okta identity provider configuration for Clisso, with the name
 `my-provider`.
@@ -164,6 +171,11 @@ The `--username` flag is optional, and allows Clisso to always use the given val
 username when retrieving credentials for apps which use this provider. Omitting this flag will make
 Clisso prompt for a username every time.
 
+The `--duration` flag is optional. If specified sessions will be assumed with this duration instead
+of the default 14400 seconds (4h). Valid values are between 3600 and 43200 seconds. Has to be
+configured on the role in AWS, too. If a mismatch is detected clisso will provide the `awscli`
+command-line to change it. Can be overwritten on a app level (see below).
+
 ### Deleting Providers
 
 Deleting providers using the `clisso` command isn't currently supported. To delete a provider,
@@ -177,7 +189,8 @@ To create a OneLogin app, use the following command:
 
     clisso apps create onelogin my-app \
         --provider my-provider \
-        --app-id 12345
+        --app-id 12345 \
+        --duration 3600
 
 The example above creates a OneLogin app configuration for Clisso, with the name `my-app`.
 
@@ -191,13 +204,20 @@ manually configure the app ID for every app.
 >NOTE: The ID seen in the browser URL when visiting a OneLogin app as a user is **NOT** the app ID.
 >Only a OneLogin administrator can obtain an app ID.
 
+The `--duration` flag is optional, defaults to the value set at the provider level. Valid values are
+between 3600 and 43200 seconds. Can be used to raise or lower the session duration on a per app basis,
+depending on the security needs for the specific app. Has to be configured on the role in AWS as the
+default maximum is 3600 seconds. If a mismatch is detected clisso will provide the `awscli`
+command-line to change it.
+
 #### Okta
 
 To create an Okta app, use the following command:
 
     clisso apps create okta my-app \
         --provider my-provider \
-        --url https://mycompany.okta.com/home/amazon_aws/xxxxxxxxxxxxxxxxxxxx/137
+        --url https://mycompany.okta.com/home/amazon_aws/xxxxxxxxxxxxxxxxxxxx/137 \
+        --duration 3600
 
 The example above creates an Okta app configuration for Clisso, with the name `my-app`.
 
@@ -209,6 +229,12 @@ clicking an app in the **Applications** view. The embed link is on the **General
 
 >NOTE: An Okta embed link must not contain an HTTP query, only the base URL. For AWS apps, the link
 should end with `/137`.
+
+The `--duration` flag is optional, defaults to the value set at the provider level. Valid values are
+between 3600 and 43200 seconds. Can be used to raise or lower the session duration on a per app basis,
+depending on the security needs for the specific app. Has to be configured on the role in AWS as the
+default maximum is 3600 seconds. If a mismatch is detected clisso will provide the `awscli`
+command-line to change it.
 
 ### Deleting Apps
 

--- a/README.md
+++ b/README.md
@@ -144,9 +144,12 @@ The `--username` flag is optional, and allows Clisso to always use the given val
 username when retrieving credentials for apps which use this provider. Omitting this flag will make
 Clisso prompt for a username every time.
 
-The `--duration` flag is optional. If specified, sessions will be assumed with the provided duration, in seconds, instead of the default of 14400 (4 hours). Valid values are between 3600 and 43200 seconds. The max session duration has to be
-configured on the role in AWS. If a longer session time is requested than what is configured on the AWS role, Clisso will provide the `awscli`
-command to change it. The default duration specified on provider level can be overridden on a per app level (see below).
+The `--duration` flag is optional. If specified, sessions will be assumed with the provided
+duration, in seconds, instead of the default of 14400 (4 hours). Valid values are between 3600 and
+43200 seconds. The max session duration has to be configured on the role in AWS. If a longer
+session time is requested than what is configured on the AWS role, Clisso will provide the `awscli`
+command to change it. The default duration specified on provider level can be overridden on a per
+app level (see below).
 
 #### Okta
 
@@ -170,10 +173,12 @@ The `--username` flag is optional, and allows Clisso to always use the given val
 username when retrieving credentials for apps which use this provider. Omitting this flag will make
 Clisso prompt for a username every time.
 
-The `--duration` flag is optional. If specified, sessions will be assumed with the provided duration, in seconds, instead of the default of 14400 (4 hours). Valid values are between 3600 and 43200 seconds. The max session duration has to be
-configured on the role in AWS. If a longer session time is requested than what is configured on the AWS role, Clisso will provide the `awscli`
-command to change it. The default duration specified on provider level can be overridden on a per app level (see below).
-
+The `--duration` flag is optional. If specified, sessions will be assumed with the provided
+duration, in seconds, instead of the default of 14400 (4 hours). Valid values are between 3600 and
+43200 seconds. The max session duration has to be configured on the role in AWS. If a longer
+session time is requested than what is configured on the AWS role, Clisso will provide the `awscli`
+command to change it. The default duration specified on provider level can be overridden on a per
+app level (see below).
 ### Deleting Providers
 
 Deleting providers using the `clisso` command isn't currently supported. To delete a provider,
@@ -202,10 +207,11 @@ manually configure the app ID for every app.
 >NOTE: The ID seen in the browser URL when visiting a OneLogin app as a user is **NOT** the app ID.
 >Only a OneLogin administrator can obtain an app ID.
 
-The `--duration` flag is optional and defaults to the value set at the provider level. Valid values are
-between 3600 and 43200 seconds. Can be used to raise or lower the session duration for an individual app,
-depending on the security needs for the specific app. The value used here has to match the max session duration configured on the AWS role; the default maximum is 3600 seconds. If a mismatch is detected Clisso will provide the `awscli`
-command to change it.
+The `--duration` flag is optional and defaults to the value set at the provider level. Valid values
+are between 3600 and 43200 seconds. Can be used to raise or lower the session duration for an
+individual app, depending on the security needs for the specific app. The value used here has to
+match the max session duration configured on the AWS role; the default maximum is 3600 seconds. If
+a mismatch is detected Clisso will provide the `awscli` command to change it.
 
 #### Okta
 
@@ -227,10 +233,11 @@ clicking an app in the **Applications** view. The embed link is on the **General
 >NOTE: An Okta embed link must not contain an HTTP query, only the base URL. For AWS apps, the link
 should end with `/137`.
 
-The `--duration` flag is optional and defaults to the value set at the provider level. Valid values are
-between 3600 and 43200 seconds. Can be used to raise or lower the session duration for an individual app,
-depending on the security needs for the specific app. The value used here has to match the max session duration configured on the AWS role; the default maximum is 3600 seconds. If a mismatch is detected Clisso will provide the `awscli`
-command to change it.
+The `--duration` flag is optional and defaults to the value set at the provider level. Valid values
+are between 3600 and 43200 seconds. Can be used to raise or lower the session duration for an
+individual app, depending on the security needs for the specific app. The value used here has to
+match the max session duration configured on the AWS role; the default maximum is 3600 seconds. If
+a mismatch is detected Clisso will provide the `awscli` command to change it.
 
 ### Deleting Apps
 

--- a/README.md
+++ b/README.md
@@ -148,8 +148,8 @@ The `--duration` flag is optional. If specified, sessions will be assumed with t
 duration, in seconds, instead of the default of 3600 (1 hour). Valid values are between 3600 and
 43200 seconds. The [max session duration][12] has be equal to or lower than what is configured on
 the role in AWS. If a longer session time is requested than what is configured on the AWS role,
-Clisso will lower the duration and retry. The default duration specified on provider level can be
-overridden on a per app level (see below).
+Clisso will fallback to a duration of 3600. The default duration specified for the provider can be
+overridden on a per-app basis (see below).
 
 #### Okta
 
@@ -177,8 +177,8 @@ The `--duration` flag is optional. If specified, sessions will be assumed with t
 duration, in seconds, instead of the default of 3600 (1 hour). Valid values are between 3600 and
 43200 seconds. The [max session duration][12] has be equal to or lower than what is configured on
 the role in AWS. If a longer session time is requested than what is configured on the AWS role,
-Clisso will lower the duration and retry. The default duration specified on provider level can be
-overridden on a per app level (see below).
+Clisso will fallback to a duration of 3600. The default duration specified for the provider can be
+overridden on a per-app basis (see below).
 
 ### Deleting Providers
 
@@ -210,10 +210,9 @@ manually configure the app ID for every app.
 
 The `--duration` flag is optional and defaults to the value set at the provider level. Valid values
 are between 3600 and 43200 seconds. Can be used to raise or lower the session duration for an
-individual app, depending on the security needs for the specific app. The [max session duration][12]
-has be equal to or lower than what is configured on the role in AWS. The default maximum is 3600
-seconds. If a mismatch is detected Clisso will try to assume the role with a duration of 3600
-seconds.
+individual app. The [max session duration][12] has be equal to or lower than what is configured on
+the role in AWS. The default maximum is 3600 seconds. If the requested duration exceeds the
+configured maximum Clisso will fallback to 3600 seconds.
 
 #### Okta
 
@@ -237,10 +236,9 @@ should end with `/137`.
 
 The `--duration` flag is optional and defaults to the value set at the provider level. Valid values
 are between 3600 and 43200 seconds. Can be used to raise or lower the session duration for an
-individual app, depending on the security needs for the specific app. The [max session duration][12]
-has be equal to or lower than what is configured on the role in AWS. The default maximum is 3600
-seconds. If a mismatch is detected Clisso will try to assume the role with a duration of 3600
-seconds.
+individual app. The [max session duration][12] has be equal to or lower than what is configured on
+the role in AWS. The default maximum is 3600 seconds. If the requested duration exceeds the
+configured maximum Clisso will fallback to 3600 seconds.
 
 ### Deleting Apps
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ username when retrieving credentials for apps which use this provider. Omitting 
 Clisso prompt for a username every time.
 
 The `--duration` flag is optional. If specified, sessions will be assumed with the provided
-duration, in seconds, instead of the default of 14400 (4 hours). Valid values are between 3600 and
+duration, in seconds, instead of the default of 3600 (1 hour). Valid values are between 3600 and
 43200 seconds. The [max session duration](12) has be equal to or lower than what is configured on
 the role in AWS. If a longer session time is requested than what is configured on the AWS role,
 Clisso will lower the duration and retry. The default duration specified on provider level can be
@@ -174,7 +174,7 @@ username when retrieving credentials for apps which use this provider. Omitting 
 Clisso prompt for a username every time.
 
 The `--duration` flag is optional. If specified, sessions will be assumed with the provided
-duration, in seconds, instead of the default of 14400 (4 hours). Valid values are between 3600 and
+duration, in seconds, instead of the default of 3600 (1 hour). Valid values are between 3600 and
 43200 seconds. The [max session duration](12) has be equal to or lower than what is configured on
 the role in AWS. If a longer session time is requested than what is configured on the AWS role,
 Clisso will lower the duration and retry. The default duration specified on provider level can be

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Clisso prompt for a username every time.
 
 The `--duration` flag is optional. If specified, sessions will be assumed with the provided
 duration, in seconds, instead of the default of 3600 (1 hour). Valid values are between 3600 and
-43200 seconds. The [max session duration](12) has be equal to or lower than what is configured on
+43200 seconds. The [max session duration][12] has be equal to or lower than what is configured on
 the role in AWS. If a longer session time is requested than what is configured on the AWS role,
 Clisso will lower the duration and retry. The default duration specified on provider level can be
 overridden on a per app level (see below).
@@ -175,7 +175,7 @@ Clisso prompt for a username every time.
 
 The `--duration` flag is optional. If specified, sessions will be assumed with the provided
 duration, in seconds, instead of the default of 3600 (1 hour). Valid values are between 3600 and
-43200 seconds. The [max session duration](12) has be equal to or lower than what is configured on
+43200 seconds. The [max session duration][12] has be equal to or lower than what is configured on
 the role in AWS. If a longer session time is requested than what is configured on the AWS role,
 Clisso will lower the duration and retry. The default duration specified on provider level can be
 overridden on a per app level (see below).
@@ -210,7 +210,7 @@ manually configure the app ID for every app.
 
 The `--duration` flag is optional and defaults to the value set at the provider level. Valid values
 are between 3600 and 43200 seconds. Can be used to raise or lower the session duration for an
-individual app, depending on the security needs for the specific app. The [max session duration](12)
+individual app, depending on the security needs for the specific app. The [max session duration][12]
 has be equal to or lower than what is configured on the role in AWS. The default maximum is 3600
 seconds. If a mismatch is detected Clisso will try to assume the role with a duration of 3600
 seconds.
@@ -237,7 +237,7 @@ should end with `/137`.
 
 The `--duration` flag is optional and defaults to the value set at the provider level. Valid values
 are between 3600 and 43200 seconds. Can be used to raise or lower the session duration for an
-individual app, depending on the security needs for the specific app. The [max session duration](12)
+individual app, depending on the security needs for the specific app. The [max session duration][12]
 has be equal to or lower than what is configured on the role in AWS. The default maximum is 3600
 seconds. If a mismatch is detected Clisso will try to assume the role with a duration of 3600
 seconds.

--- a/aws/sts.go
+++ b/aws/sts.go
@@ -13,7 +13,7 @@ import (
 var ErrInvalidSessionDuration = errors.New("InvalidSessionDuration")
 
 // AssumeSAMLRole asumes a Role using the SAMLAssertion specified. If the duration cannot be meet it transperently lowers the duration and sets the returned bool to true to signal that a message should be displayed
-func AssumeSAMLRole(PrincipalArn, RoleArn, SAMLAssertion, profile string, duration int64) (*Credentials, error) {
+func AssumeSAMLRole(PrincipalArn, RoleArn, SAMLAssertion string, duration int64) (*Credentials, error) {
 	return assumeSAMLRole(PrincipalArn, RoleArn, SAMLAssertion, duration, false)
 }
 

--- a/aws/sts.go
+++ b/aws/sts.go
@@ -13,7 +13,8 @@ import (
 var ErrInvalidSessionDuration = errors.New("InvalidSessionDuration")
 
 // AssumeSAMLRole asumes a Role using the SAMLAssertion specified. If the duration cannot be meet
-// it transperently lowers the duration and returns an error in parallel to the valid credentials.
+// it transperently lowers the duration to the minimal valid value of 3600 seconds and returns an
+// error in parallel to the valid credentials.
 func AssumeSAMLRole(PrincipalArn, RoleArn, SAMLAssertion string, duration int64) (*Credentials, error) {
 	creds, err := assumeSAMLRole(PrincipalArn, RoleArn, SAMLAssertion, duration, false)
 	if err == ErrInvalidSessionDuration {
@@ -39,8 +40,8 @@ func assumeSAMLRole(PrincipalArn, RoleArn, SAMLAssertion string, duration int64,
 
 	aResp, err := svc.AssumeRoleWithSAML(&input)
 	if err != nil {
-		// The role might not yet support the requested duration, let's catch and try to lower in 1h
-		// steps. There is - as of now - no other way than to do a string comparison.
+		// The role might not yet support the requested duration, let's catch and return a specific
+		// error. There is - as of now - no other way than to do a string comparison.
 		if strings.HasPrefix(err.Error(), "ValidationError: The requested DurationSeconds exceeds the MaxSessionDuration set for this role") && duration > 3600 && duration <= 43200 {
 			return nil, ErrInvalidSessionDuration
 		}

--- a/aws/sts.go
+++ b/aws/sts.go
@@ -10,9 +10,17 @@ import (
 )
 
 const (
+	// A friendly message to show to the user when a requested duration exceeds the configured
+	// maximum.
+	DurationExceededMessage = "The requested duration exceeded the allowed maximum. Falling " +
+		"back to 1 hour.\nTo update the maximum session duration you can use the following " +
+		"command:\n\naws iam update-role --role-name <role_name> --max-session-duration " +
+		"<duration>\n\nFor more information please refer to the AWS documentation:\n" +
+		"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_manage_modify.html"
 	// The error message STS returns when attempting to assume a role with a duration longer than
 	// the configured maximum for that role.
-	ErrInvalidSessionDuration = "The requested DurationSeconds exceeds the MaxSessionDuration set for this role."
+	ErrInvalidSessionDuration = "The requested DurationSeconds exceeds the MaxSessionDuration " +
+		"set for this role."
 	// A custom error which indicates that the requested duration exceeded the configured maximum.
 	// TODO Replace this with a custom error type.
 	ErrDurationExceeded = "DurationExceeded"

--- a/aws/sts.go
+++ b/aws/sts.go
@@ -12,7 +12,8 @@ import (
 
 var ErrInvalidSessionDuration = errors.New("InvalidSessionDuration")
 
-// AssumeSAMLRole asumes a Role using the SAMLAssertion specified. If the duration cannot be meet it transperently lowers the duration and sets the returned bool to true to signal that a message should be displayed
+// AssumeSAMLRole asumes a Role using the SAMLAssertion specified. If the duration cannot be meet
+// it transperently lowers the duration and returns an error in parallel to the valid credentials.
 func AssumeSAMLRole(PrincipalArn, RoleArn, SAMLAssertion string, duration int64) (*Credentials, error) {
 	return assumeSAMLRole(PrincipalArn, RoleArn, SAMLAssertion, duration, false)
 }
@@ -31,7 +32,8 @@ func assumeSAMLRole(PrincipalArn, RoleArn, SAMLAssertion string, duration int64,
 
 	aResp, err := svc.AssumeRoleWithSAML(&input)
 	if err != nil {
-		// The role might not yet support the requested duration, let's catch and try to lower in 1h steps. There is as of now no other way than to do a string comparison.
+		// The role might not yet support the requested duration, let's catch and try to lower in 1h
+		// steps. There is - as of now - no other way than to do a string comparison.
 		if strings.HasPrefix(err.Error(), "ValidationError: The requested DurationSeconds exceeds the MaxSessionDuration set for this role") && duration > 3600 && duration <= 43200 {
 			duration -= 3600
 			return assumeSAMLRole(PrincipalArn, RoleArn, SAMLAssertion, duration, true)

--- a/aws/sts.go
+++ b/aws/sts.go
@@ -2,32 +2,46 @@ package aws
 
 import (
 	"errors"
-	"fmt"
-	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts"
 )
 
-var ErrInvalidSessionDuration = errors.New("InvalidSessionDuration")
+const (
+	// The error message STS returns when attempting to assume a role with a duration longer than
+	// the configured maximum for that role.
+	ErrInvalidSessionDuration = "The requested DurationSeconds exceeds the MaxSessionDuration set for this role."
+	// A custom error which indicates that the requested duration exceeded the configured maximum.
+	// TODO Replace this with a custom error type.
+	ErrDurationExceeded = "DurationExceeded"
+)
 
-// AssumeSAMLRole asumes a Role using the SAMLAssertion specified. If the duration cannot be meet
-// it transperently lowers the duration to the minimal valid value of 3600 seconds and returns an
-// error in parallel to the valid credentials.
+// AssumeSAMLRole assumes an AWS IAM role using a SAML assertion.
+// In cases where the requested session duration is higher than the maximum allowed on AWS, STS
+// returns a specific error message to indicate that. In this case we return a custom error to the
+// caller to allow special handling such as retrying with a lower duration.
 func AssumeSAMLRole(PrincipalArn, RoleArn, SAMLAssertion string, duration int64) (*Credentials, error) {
-	creds, err := assumeSAMLRole(PrincipalArn, RoleArn, SAMLAssertion, duration, false)
-	if err == ErrInvalidSessionDuration {
-		// the requested duration was invalid. So try again with a minimum of 3600s and return an
-		// EErrInvalidSessionDuration error, too.
-		return assumeSAMLRole(PrincipalArn, RoleArn, SAMLAssertion, 3600, true)
+	creds, err := assumeSAMLRole(PrincipalArn, RoleArn, SAMLAssertion, duration)
+	if err != nil {
+		// Verify error is an AWS error.
+		if awsErr, ok := err.(awserr.Error); ok {
+			// Check if error indicates exceeded duration.
+			if awsErr.Message() == ErrInvalidSessionDuration {
+				// Return a custom error to allow the caller to retry etc.
+				// TODO Return a custom error type instead of a special value:
+				// https://dave.cheney.net/2014/12/24/inspecting-errors
+				return nil, errors.New(ErrDurationExceeded)
+			}
+		}
+		return nil, err
 	}
 
 	return creds, nil
 }
 
-func assumeSAMLRole(PrincipalArn, RoleArn, SAMLAssertion string, duration int64, roleDoesNotSupportDuration bool) (*Credentials, error) {
-	// Assume role
+func assumeSAMLRole(PrincipalArn, RoleArn, SAMLAssertion string, duration int64) (*Credentials, error) {
 	input := sts.AssumeRoleWithSAMLInput{
 		PrincipalArn:    aws.String(PrincipalArn),
 		RoleArn:         aws.String(RoleArn),
@@ -40,12 +54,7 @@ func assumeSAMLRole(PrincipalArn, RoleArn, SAMLAssertion string, duration int64,
 
 	aResp, err := svc.AssumeRoleWithSAML(&input)
 	if err != nil {
-		// The role might not yet support the requested duration, let's catch and return a specific
-		// error. There is - as of now - no other way than to do a string comparison.
-		if strings.HasPrefix(err.Error(), "ValidationError: The requested DurationSeconds exceeds the MaxSessionDuration set for this role") && duration > 3600 && duration <= 43200 {
-			return nil, ErrInvalidSessionDuration
-		}
-		return nil, fmt.Errorf("assuming role: %v", err)
+		return nil, err
 	}
 
 	keyID := *aResp.Credentials.AccessKeyId
@@ -60,9 +69,5 @@ func assumeSAMLRole(PrincipalArn, RoleArn, SAMLAssertion string, duration int64,
 		Expiration:      expiration,
 	}
 
-	if roleDoesNotSupportDuration {
-		err = ErrInvalidSessionDuration
-	}
-
-	return &creds, err
+	return &creds, nil
 }

--- a/cmd/apps.go
+++ b/cmd/apps.go
@@ -25,14 +25,14 @@ func init() {
 	// OneLogin
 	cmdAppsCreateOneLogin.Flags().StringVar(&appID, "app-id", "", "OneLogin app ID")
 	cmdAppsCreateOneLogin.Flags().StringVar(&provider, "provider", "", "Name of the Clisso provider")
-	cmdAppsCreateOneLogin.Flags().IntVar(&duration, "duration", 0, "(Optional) Validity duration session of in seconds to request")
+	cmdAppsCreateOneLogin.Flags().IntVar(&duration, "duration", 0, "(Optional) Session duration in seconds")
 	cmdAppsCreateOneLogin.MarkFlagRequired("app-id")
 	cmdAppsCreateOneLogin.MarkFlagRequired("provider")
 
 	// Okta
 	cmdAppsCreateOkta.Flags().StringVar(&provider, "provider", "", "Name of the Clisso provider")
 	cmdAppsCreateOkta.Flags().StringVar(&URL, "url", "", "Okta app URL")
-	cmdAppsCreateOkta.Flags().IntVar(&duration, "duration", 0, "(Optional) Validity duration session of in seconds to request")
+	cmdAppsCreateOkta.Flags().IntVar(&duration, "duration", 0, "(Optional) Session duration in seconds")
 	cmdAppsCreateOkta.MarkFlagRequired("provider")
 	cmdAppsCreateOkta.MarkFlagRequired("url")
 

--- a/cmd/apps.go
+++ b/cmd/apps.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"sort"
+	"strconv"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -12,6 +13,7 @@ import (
 
 // Common
 var provider string
+var duration int
 
 // OneLogin
 var appID string
@@ -23,12 +25,14 @@ func init() {
 	// OneLogin
 	cmdAppsCreateOneLogin.Flags().StringVar(&appID, "app-id", "", "OneLogin app ID")
 	cmdAppsCreateOneLogin.Flags().StringVar(&provider, "provider", "", "Name of the Clisso provider")
+	cmdAppsCreateOneLogin.Flags().IntVar(&duration, "duration", 0, "(Optional) Validity duration session of in seconds to request")
 	cmdAppsCreateOneLogin.MarkFlagRequired("app-id")
 	cmdAppsCreateOneLogin.MarkFlagRequired("provider")
 
 	// Okta
 	cmdAppsCreateOkta.Flags().StringVar(&provider, "provider", "", "Name of the Clisso provider")
 	cmdAppsCreateOkta.Flags().StringVar(&URL, "url", "", "Okta app URL")
+	cmdAppsCreateOkta.Flags().IntVar(&duration, "duration", 0, "(Optional) Validity duration session of in seconds to request")
 	cmdAppsCreateOkta.MarkFlagRequired("provider")
 	cmdAppsCreateOkta.MarkFlagRequired("url")
 
@@ -115,6 +119,14 @@ var cmdAppsCreateOneLogin = &cobra.Command{
 			"app-id":   appID,
 			"provider": provider,
 		}
+
+		if duration != 0 {
+			if duration < 3600 || duration > 43200 {
+				log.Fatal(color.RedString("The specified duration is invalid. The range STS accepts is 3600 - 43200 seconds."))
+			}
+			conf["duration"] = strconv.Itoa(duration)
+		}
+
 		viper.Set(fmt.Sprintf("apps.%s", name), conf)
 
 		// Write config to file
@@ -157,6 +169,14 @@ var cmdAppsCreateOkta = &cobra.Command{
 			"provider": provider,
 			"url":      URL,
 		}
+
+		if duration != 0 {
+			if duration < 3600 || duration > 43200 {
+				log.Fatal(color.RedString("The specified duration is invalid. The range STS accepts is 3600 - 43200 seconds."))
+			}
+			conf["duration"] = strconv.Itoa(duration)
+		}
+
 		viper.Set(fmt.Sprintf("apps.%s", name), conf)
 
 		// Write config to file

--- a/cmd/apps.go
+++ b/cmd/apps.go
@@ -121,6 +121,7 @@ var cmdAppsCreateOneLogin = &cobra.Command{
 		}
 
 		if duration != 0 {
+			// the duration parameter was provided, let's check if the duration is in a valid range.
 			if duration < 3600 || duration > 43200 {
 				log.Fatal(color.RedString("The specified duration is invalid. The range STS accepts is 3600 - 43200 seconds."))
 			}
@@ -171,6 +172,7 @@ var cmdAppsCreateOkta = &cobra.Command{
 		}
 
 		if duration != 0 {
+			// the duration parameter was provided, let's check if the duration is in a valid range.
 			if duration < 3600 || duration > 43200 {
 				log.Fatal(color.RedString("The specified duration is invalid. The range STS accepts is 3600 - 43200 seconds."))
 			}

--- a/cmd/apps.go
+++ b/cmd/apps.go
@@ -121,7 +121,7 @@ var cmdAppsCreateOneLogin = &cobra.Command{
 		}
 
 		if duration != 0 {
-			// the duration parameter was provided, let's check if the duration is in a valid range.
+			// if duration is non zero, the parameter was provided, let's check if the duration is in a valid range.
 			if duration < 3600 || duration > 43200 {
 				log.Fatal(color.RedString("The specified duration is invalid. The range STS accepts is 3600 - 43200 seconds."))
 			}

--- a/cmd/apps.go
+++ b/cmd/apps.go
@@ -121,9 +121,9 @@ var cmdAppsCreateOneLogin = &cobra.Command{
 		}
 
 		if duration != 0 {
-			// if duration is non zero, the parameter was provided, let's check if the duration is in a valid range.
+			// Duration specified - validate value
 			if duration < 3600 || duration > 43200 {
-				log.Fatal(color.RedString("The specified duration is invalid. The range STS accepts is 3600 - 43200 seconds."))
+				log.Fatal(color.RedString("Invalid duration Specified. Valid values: 3600 - 43200"))
 			}
 			conf["duration"] = strconv.Itoa(duration)
 		}
@@ -172,9 +172,9 @@ var cmdAppsCreateOkta = &cobra.Command{
 		}
 
 		if duration != 0 {
-			// the duration parameter was provided, let's check if the duration is in a valid range.
+			// Duration specified - validate value
 			if duration < 3600 || duration > 43200 {
-				log.Fatal(color.RedString("The specified duration is invalid. The range STS accepts is 3600 - 43200 seconds."))
+				log.Fatal(color.RedString("Invalid duration Specified. Valid values: 3600 - 43200"))
 			}
 			conf["duration"] = strconv.Itoa(duration)
 		}

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -84,7 +84,10 @@ If no app is specified, the selected app (if configured) will be assumed.`,
 			log.Fatalf(color.RedString("Could not get provider type for provider '%s'"), provider)
 		}
 
-		// Set some sane default values for provider and app level durations
+		// Set some sane default values for provider and app level durations.
+		// We can't do this earlier because we don't know what the provider or app name will be.
+		// The value is checked in order (app.duration -> provider.duration -> coded default of 4h)
+		// and the first match is taken.
 		viper.SetDefault(fmt.Sprintf("providers.%s.duration", provider), 14400)
 		viper.SetDefault(fmt.Sprintf("apps.%s.duration", app), viper.GetInt64(fmt.Sprintf("providers.%s.duration", provider)))
 		// Get the duration to be used.

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -84,8 +84,14 @@ If no app is specified, the selected app (if configured) will be assumed.`,
 			log.Fatalf(color.RedString("Could not get provider type for provider '%s'"), provider)
 		}
 
+		// Set some sane default values for provider and app level durations
+		viper.SetDefault(fmt.Sprintf("providers.%s.duration", provider), 14400)
+		viper.SetDefault(fmt.Sprintf("apps.%s.duration", app), viper.GetInt64(fmt.Sprintf("providers.%s.duration", provider)))
+		// Get the duration to be used.
+		duration := viper.GetInt64(fmt.Sprintf("apps.%s.duration", app))
+
 		if pType == "onelogin" {
-			creds, err := onelogin.Get(app, provider)
+			creds, err := onelogin.Get(app, provider, duration)
 			if err != nil {
 				log.Fatal(color.RedString("Could not get temporary credentials: "), err)
 			}
@@ -95,7 +101,7 @@ If no app is specified, the selected app (if configured) will be assumed.`,
 				log.Fatalf(color.RedString("Error processing credentials: %v"), err)
 			}
 		} else if pType == "okta" {
-			creds, err := okta.Get(app, provider)
+			creds, err := okta.Get(app, provider, duration)
 			if err != nil {
 				log.Fatal(color.RedString("Could not get temporary credentials: "), err)
 			}

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -86,9 +86,9 @@ If no app is specified, the selected app (if configured) will be assumed.`,
 
 		// Set some sane default values for provider and app level durations.
 		// We can't do this earlier because we don't know what the provider or app name will be.
-		// The value is checked in order (app.duration -> provider.duration -> coded default of 4h)
+		// The value is checked in order (app.duration -> provider.duration -> coded default of 1h)
 		// and the first match is taken.
-		viper.SetDefault(fmt.Sprintf("providers.%s.duration", provider), 14400)
+		viper.SetDefault(fmt.Sprintf("providers.%s.duration", provider), 3600)
 		viper.SetDefault(fmt.Sprintf("apps.%s.duration", app), viper.GetInt64(fmt.Sprintf("providers.%s.duration", provider)))
 		// Get the duration to be used.
 		duration := viper.GetInt64(fmt.Sprintf("apps.%s.duration", app))

--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+var testdata = []struct {
+	app      int64
+	provider int64
+	result   int64
+}{
+	{0, 0, 3600},
+	{7200, 0, 7200},
+	{0, 7200, 7200},
+	{7200, 14400, 7200},
+}
+
+func TestSessionDuration(t *testing.T) {
+	for _, tc := range testdata {
+		viper.Set("apps.test.duration", tc.app)
+		viper.Set("providers.test.duration", tc.provider)
+
+		res := sessionDuration("test", "test")
+		if res != tc.result {
+			t.Fatalf("Invalid duration: got %v, want: %v", res, tc.result)
+		}
+	}
+}

--- a/cmd/providers.go
+++ b/cmd/providers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"sort"
+	"strconv"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -16,6 +17,7 @@ var clientSecret string
 var subdomain string
 var username string
 var region string
+var providerDuration int
 
 // Okta
 var baseURL string
@@ -31,6 +33,7 @@ func init() {
 		"Don't ask for a username and use this instead")
 	cmdProvidersCreateOneLogin.Flags().StringVar(&region, "region", "US",
 		"Region in which the OneLogin API lives")
+	cmdProvidersCreateOneLogin.Flags().IntVar(&providerDuration, "duration", 14400, "(Optional) Default session duration validity assumed with this provider")
 
 	cmdProvidersCreateOneLogin.MarkFlagRequired("client-id")
 	cmdProvidersCreateOneLogin.MarkFlagRequired("client-secret")
@@ -40,6 +43,8 @@ func init() {
 	cmdProvidersCreateOkta.Flags().StringVar(&baseURL, "base-url", "", "Okta base URL")
 	cmdProvidersCreateOkta.Flags().StringVar(&username, "username", "",
 		"Don't ask for a username and use this instead")
+	cmdProvidersCreateOkta.Flags().IntVar(&providerDuration, "duration", 14400, "(Optional) Default session duration validity assumed with this provider")
+
 	cmdProvidersCreateOkta.MarkFlagRequired("base-url")
 
 	// Build command tree
@@ -113,6 +118,12 @@ var cmdProvidersCreateOneLogin = &cobra.Command{
 			"username":      username,
 			"region":        region,
 		}
+		if providerDuration != 0 {
+			if providerDuration < 3600 || providerDuration > 43200 {
+				log.Fatal(color.RedString("The specified duration is invalid. The range STS accepts is 3600 - 43200 seconds."))
+			}
+			conf["duration"] = strconv.Itoa(providerDuration)
+		}
 		viper.Set(fmt.Sprintf("providers.%s", name), conf)
 
 		// Write config to file
@@ -141,6 +152,12 @@ var cmdProvidersCreateOkta = &cobra.Command{
 			"base-url": baseURL,
 			"type":     "okta",
 			"username": username,
+		}
+		if providerDuration != 0 {
+			if providerDuration < 3600 || providerDuration > 43200 {
+				log.Fatal(color.RedString("The specified duration is invalid. The range STS accepts is 3600 - 43200 seconds."))
+			}
+			conf["duration"] = strconv.Itoa(providerDuration)
 		}
 		viper.Set(fmt.Sprintf("providers.%s", name), conf)
 

--- a/cmd/providers.go
+++ b/cmd/providers.go
@@ -119,9 +119,9 @@ var cmdProvidersCreateOneLogin = &cobra.Command{
 			"region":        region,
 		}
 		if providerDuration != 0 {
-			// if duration is non zero, the parameter was provided, let's check if the duration is in a valid range.
+			// Duration specified - validate value
 			if providerDuration < 3600 || providerDuration > 43200 {
-				log.Fatal(color.RedString("The specified duration is invalid. The range STS accepts is 3600 - 43200 seconds."))
+				log.Fatal(color.RedString("Invalid duration Specified. Valid values: 3600 - 43200"))
 			}
 			conf["duration"] = strconv.Itoa(providerDuration)
 		}
@@ -155,8 +155,9 @@ var cmdProvidersCreateOkta = &cobra.Command{
 			"username": username,
 		}
 		if providerDuration != 0 {
+			// Duration specified - validate value
 			if providerDuration < 3600 || providerDuration > 43200 {
-				log.Fatal(color.RedString("The specified duration is invalid. The range STS accepts is 3600 - 43200 seconds."))
+				log.Fatal(color.RedString("Invalid duration Specified. Valid values: 3600 - 43200"))
 			}
 			conf["duration"] = strconv.Itoa(providerDuration)
 		}

--- a/cmd/providers.go
+++ b/cmd/providers.go
@@ -33,7 +33,7 @@ func init() {
 		"Don't ask for a username and use this instead")
 	cmdProvidersCreateOneLogin.Flags().StringVar(&region, "region", "US",
 		"Region in which the OneLogin API lives")
-	cmdProvidersCreateOneLogin.Flags().IntVar(&providerDuration, "duration", 14400, "(Optional) Default session duration validity assumed with this provider")
+	cmdProvidersCreateOneLogin.Flags().IntVar(&providerDuration, "duration", 0, "(Optional) Default session duration in seconds")
 
 	cmdProvidersCreateOneLogin.MarkFlagRequired("client-id")
 	cmdProvidersCreateOneLogin.MarkFlagRequired("client-secret")
@@ -43,7 +43,7 @@ func init() {
 	cmdProvidersCreateOkta.Flags().StringVar(&baseURL, "base-url", "", "Okta base URL")
 	cmdProvidersCreateOkta.Flags().StringVar(&username, "username", "",
 		"Don't ask for a username and use this instead")
-	cmdProvidersCreateOkta.Flags().IntVar(&providerDuration, "duration", 14400, "(Optional) Default session duration validity assumed with this provider")
+	cmdProvidersCreateOkta.Flags().IntVar(&providerDuration, "duration", 0, "(Optional) Default session duration in seconds")
 
 	cmdProvidersCreateOkta.MarkFlagRequired("base-url")
 

--- a/cmd/providers.go
+++ b/cmd/providers.go
@@ -119,6 +119,7 @@ var cmdProvidersCreateOneLogin = &cobra.Command{
 			"region":        region,
 		}
 		if providerDuration != 0 {
+			// if duration is non zero, the parameter was provided, let's check if the duration is in a valid range.
 			if providerDuration < 3600 || providerDuration > 43200 {
 				log.Fatal(color.RedString("The specified duration is invalid. The range STS accepts is 3600 - 43200 seconds."))
 			}

--- a/okta/get.go
+++ b/okta/get.go
@@ -107,8 +107,10 @@ func Get(app, provider string, duration int64) (*aws.Credentials, error) {
 	// the default duration might be shorter than what is configured on AWS side. The code above
 	// selected the minimum duration. If more was requested print an info.
 	if err == aws.ErrInvalidSessionDuration {
-		fmt.Printf("The role does not support the requested duration of %v. To have a max session duration for up to 12h run:\n", duration)
-		fmt.Printf("aws iam update-role --role-name %v --max-session-duration 43200 --profile %v\n", arn.Role[strings.LastIndex(arn.Role, "/")+1:], app)
+		fmt.Printf("The role does not support the requested duration of %v. To have a max session "+
+			"duration for up to 12h run:\n", duration)
+		fmt.Printf("aws iam update-role --role-name %v --max-session-duration 43200 --profile %v\n",
+			arn.Role[strings.LastIndex(arn.Role, "/")+1:], app)
 		err = nil
 	}
 

--- a/okta/get.go
+++ b/okta/get.go
@@ -101,7 +101,7 @@ func Get(app, provider string, duration int64) (*aws.Credentials, error) {
 	}
 
 	s.Start()
-	creds, err := aws.AssumeSAMLRole(arn.Provider, arn.Role, *samlAssertion, app, duration)
+	creds, err := aws.AssumeSAMLRole(arn.Provider, arn.Role, *samlAssertion, duration)
 	s.Stop()
 
 	// the default duration might be shorter than what is configured on AWS side. The code above

--- a/okta/get.go
+++ b/okta/get.go
@@ -2,6 +2,7 @@ package okta
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/allcloud-io/clisso/aws"
 	"github.com/allcloud-io/clisso/config"
@@ -102,6 +103,14 @@ func Get(app, provider string, duration int64) (*aws.Credentials, error) {
 	s.Start()
 	creds, err := aws.AssumeSAMLRole(arn.Provider, arn.Role, *samlAssertion, app, duration)
 	s.Stop()
+
+	// the default duration might be shorter than what is configured on AWS side. The code above
+	// selected the minimum duration. If more was requested print an info.
+	if err == aws.ErrInvalidSessionDuration {
+		fmt.Printf("The role does not support the requested duration of %v. To have a max session duration for up to 12h run:\n", duration)
+		fmt.Printf("\raws iam update-role --role-name %v --max-session-duration 43200 --profile %v\n", arn.Role[strings.LastIndex(arn.Role, "/")+1:], app)
+		err = nil
+	}
 
 	return creds, err
 }

--- a/okta/get.go
+++ b/okta/get.go
@@ -108,7 +108,7 @@ func Get(app, provider string, duration int64) (*aws.Credentials, error) {
 	// selected the minimum duration. If more was requested print an info.
 	if err == aws.ErrInvalidSessionDuration {
 		fmt.Printf("The role does not support the requested duration of %v. To have a max session duration for up to 12h run:\n", duration)
-		fmt.Printf("\raws iam update-role --role-name %v --max-session-duration 43200 --profile %v\n", arn.Role[strings.LastIndex(arn.Role, "/")+1:], app)
+		fmt.Printf("aws iam update-role --role-name %v --max-session-duration 43200 --profile %v\n", arn.Role[strings.LastIndex(arn.Role, "/")+1:], app)
 		err = nil
 	}
 

--- a/okta/get.go
+++ b/okta/get.go
@@ -2,12 +2,13 @@ package okta
 
 import (
 	"fmt"
-	"strings"
+	"log"
 
 	"github.com/allcloud-io/clisso/aws"
 	"github.com/allcloud-io/clisso/config"
 	"github.com/allcloud-io/clisso/saml"
 	"github.com/allcloud-io/clisso/spinner"
+	"github.com/fatih/color"
 	"github.com/howeyc/gopass"
 )
 
@@ -104,14 +105,13 @@ func Get(app, provider string, duration int64) (*aws.Credentials, error) {
 	creds, err := aws.AssumeSAMLRole(arn.Provider, arn.Role, *samlAssertion, duration)
 	s.Stop()
 
-	// the default duration might be shorter than what is configured on AWS side. The code above
-	// selected the minimum duration. If more was requested print an info.
-	if err == aws.ErrInvalidSessionDuration {
-		fmt.Printf("The role does not support the requested duration of %v. To have a max session "+
-			"duration for up to 12h run:\n", duration)
-		fmt.Printf("aws iam update-role --role-name %v --max-session-duration 43200 --profile %v\n",
-			arn.Role[strings.LastIndex(arn.Role, "/")+1:], app)
-		err = nil
+	if err != nil {
+		if err.Error() == aws.ErrDurationExceeded {
+			log.Println(color.YellowString("Requested duration exceeded allowed maximum. Falling back to 1 hour."))
+			s.Start()
+			creds, err = aws.AssumeSAMLRole(arn.Provider, arn.Role, *samlAssertion, 3600)
+			s.Stop()
+		}
 	}
 
 	return creds, err

--- a/okta/get.go
+++ b/okta/get.go
@@ -107,7 +107,7 @@ func Get(app, provider string, duration int64) (*aws.Credentials, error) {
 
 	if err != nil {
 		if err.Error() == aws.ErrDurationExceeded {
-			log.Println(color.YellowString("Requested duration exceeded allowed maximum. Falling back to 1 hour."))
+			log.Println(color.YellowString(aws.DurationExceededMessage))
 			s.Start()
 			creds, err = aws.AssumeSAMLRole(arn.Provider, arn.Role, *samlAssertion, 3600)
 			s.Stop()

--- a/okta/get.go
+++ b/okta/get.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Get gets temporary credentials for the given app.
-func Get(app, provider string) (*aws.Credentials, error) {
+func Get(app, provider string, duration int64) (*aws.Credentials, error) {
 	// Get provider config
 	p, err := config.GetOktaProvider(provider)
 	if err != nil {
@@ -100,7 +100,7 @@ func Get(app, provider string) (*aws.Credentials, error) {
 	}
 
 	s.Start()
-	creds, err := aws.AssumeSAMLRole(arn.Provider, arn.Role, *samlAssertion)
+	creds, err := aws.AssumeSAMLRole(arn.Provider, arn.Role, *samlAssertion, app, duration)
 	s.Stop()
 
 	return creds, err

--- a/onelogin/get.go
+++ b/onelogin/get.go
@@ -26,7 +26,7 @@ const (
 
 // Get gets temporary credentials for the given app.
 // TODO Move AWS logic outside this function.
-func Get(app, provider string) (*aws.Credentials, error) {
+func Get(app, provider string, duration int64) (*aws.Credentials, error) {
 	// Read config
 	p, err := config.GetOneLoginProvider(provider)
 	if err != nil {
@@ -183,7 +183,7 @@ func Get(app, provider string) (*aws.Credentials, error) {
 	}
 
 	s.Start()
-	creds, err := aws.AssumeSAMLRole(arn.Provider, arn.Role, rMfa.Data)
+	creds, err := aws.AssumeSAMLRole(arn.Provider, arn.Role, rMfa.Data, app, duration)
 	s.Stop()
 
 	return creds, err

--- a/onelogin/get.go
+++ b/onelogin/get.go
@@ -191,7 +191,7 @@ func Get(app, provider string, duration int64) (*aws.Credentials, error) {
 	// selected the minimum duration. If more was requested print an info.
 	if err == aws.ErrInvalidSessionDuration {
 		fmt.Printf("The role does not support the requested duration of %v. To have a max session duration for up to 12h run:\n", duration)
-		fmt.Printf("\raws iam update-role --role-name %v --max-session-duration 43200 --profile %v\n", arn.Role[strings.LastIndex(arn.Role, "/")+1:], app)
+		fmt.Printf("aws iam update-role --role-name %v --max-session-duration 43200 --profile %v\n", arn.Role[strings.LastIndex(arn.Role, "/")+1:], app)
 		err = nil
 	}
 

--- a/onelogin/get.go
+++ b/onelogin/get.go
@@ -190,8 +190,10 @@ func Get(app, provider string, duration int64) (*aws.Credentials, error) {
 	// the default duration might be shorter than what is configured on AWS side. The code above
 	// selected the minimum duration. If more was requested print an info.
 	if err == aws.ErrInvalidSessionDuration {
-		fmt.Printf("The role does not support the requested duration of %v. To have a max session duration for up to 12h run:\n", duration)
-		fmt.Printf("aws iam update-role --role-name %v --max-session-duration 43200 --profile %v\n", arn.Role[strings.LastIndex(arn.Role, "/")+1:], app)
+		fmt.Printf("The role does not support the requested duration of %v. To have a max session "+
+			"duration for up to 12h run:\n", duration)
+		fmt.Printf("aws iam update-role --role-name %v --max-session-duration 43200 --profile %v\n",
+			arn.Role[strings.LastIndex(arn.Role, "/")+1:], app)
 		err = nil
 	}
 

--- a/onelogin/get.go
+++ b/onelogin/get.go
@@ -184,7 +184,7 @@ func Get(app, provider string, duration int64) (*aws.Credentials, error) {
 	}
 
 	s.Start()
-	creds, err := aws.AssumeSAMLRole(arn.Provider, arn.Role, rMfa.Data, app, duration)
+	creds, err := aws.AssumeSAMLRole(arn.Provider, arn.Role, rMfa.Data, duration)
 	s.Stop()
 
 	// the default duration might be shorter than what is configured on AWS side. The code above

--- a/onelogin/get.go
+++ b/onelogin/get.go
@@ -190,7 +190,7 @@ func Get(app, provider string, duration int64) (*aws.Credentials, error) {
 
 	if err != nil {
 		if err.Error() == aws.ErrDurationExceeded {
-			log.Println(color.YellowString("Requested duration exceeded allowed maximum. Falling back to 1 hour."))
+			log.Println(color.YellowString(aws.DurationExceededMessage))
 			s.Start()
 			creds, err = aws.AssumeSAMLRole(arn.Provider, arn.Role, rMfa.Data, 3600)
 			s.Stop()


### PR DESCRIPTION
Support a variable session duration between 3600 and 48800 seconds.

Depends/builds on #59 