### PR TITLE
Attach version number to build binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,27 +14,27 @@ test:
 
 .PHONY: darwin-386
 darwin-386:
-	GOOS=darwin GOARCH=386 $(GOBUILD) -ldflags "-X main.version=$(VERSION)" -o $(BINARY_NAME)-darwin-386 -v
+	GOOS=darwin GOARCH=386 $(GOBUILD) -ldflags "-X main.version=$(VERSION)" -o $(BINARY_NAME)-$(VERSION)-darwin-386 -v
 
 .PHONY: darwin-amd64
 darwin-amd64:
-	GOOS=darwin GOARCH=amd64 $(GOBUILD) -ldflags "-X main.version=$(VERSION)" -o $(BINARY_NAME)-darwin-amd64 -v
+	GOOS=darwin GOARCH=amd64 $(GOBUILD) -ldflags "-X main.version=$(VERSION)" -o $(BINARY_NAME)-$(VERSION)-darwin-amd64 -v
 
 .PHONY: linux-386
 linux-386:
-	GOOS=linux GOARCH=386 $(GOBUILD) -ldflags "-X main.version=$(VERSION)" -o $(BINARY_NAME)-linux-386 -v
+	GOOS=linux GOARCH=386 $(GOBUILD) -ldflags "-X main.version=$(VERSION)" -o $(BINARY_NAME)-$(VERSION)-linux-386 -v
 
 .PHONY: linux-amd64
 linux-amd64:
-	GOOS=linux GOARCH=amd64 $(GOBUILD) -ldflags "-X main.version=$(VERSION)" -o $(BINARY_NAME)-linux-amd64 -v
+	GOOS=linux GOARCH=amd64 $(GOBUILD) -ldflags "-X main.version=$(VERSION)" -o $(BINARY_NAME)-$(VERSION)-linux-amd64 -v
 
 .PHONY: windows-386
 windows-386:
-	GOOS=windows GOARCH=386 $(GOBUILD) -ldflags "-X main.version=$(VERSION)" -o $(BINARY_NAME)-windows-386.exe -v
+	GOOS=windows GOARCH=386 $(GOBUILD) -ldflags "-X main.version=$(VERSION)" -o $(BINARY_NAME)-$(VERSION)-windows-386.exe -v
 
 .PHONY: windows-amd64
 windows-amd64:
-	GOOS=windows GOARCH=amd64 $(GOBUILD) -ldflags "-X main.version=$(VERSION)" -o $(BINARY_NAME)-windows-amd64.exe -v
+	GOOS=windows GOARCH=amd64 $(GOBUILD) -ldflags "-X main.version=$(VERSION)" -o $(BINARY_NAME)-$(VERSION)-windows-amd64.exe -v
 
 .PHONY: all
 all: darwin-386 darwin-amd64 linux-386 linux-amd64 windows-386 windows-amd64


### PR DESCRIPTION
This makes it easier to understand what binary was downloaded from a release page in case multiple files exists in the users download folder. Since the bottle attached to the release has also a version number it also make it more uniform.

@johananl what do you think?