### PR TITLE
fix no roles returned even if they have been returned

### DIFF
--- a/saml/saml.go
+++ b/saml/saml.go
@@ -33,7 +33,7 @@ func Get(data string) (a ARN, err error) {
 
 	switch len(arns) {
 	case 0:
-		err = errors.New("no valid AWS roles were returned, check for extra characters on the IDP config")
+		err = errors.New("no valid AWS roles were returned")
 
 		return
 

--- a/saml/saml.go
+++ b/saml/saml.go
@@ -33,7 +33,7 @@ func Get(data string) (a ARN, err error) {
 
 	switch len(arns) {
 	case 0:
-		err = errors.New("no valid AWS roles were returned")
+		err = errors.New("no valid AWS roles were returned, check for extra characters on the IDP config")
 
 		return
 
@@ -68,7 +68,7 @@ func extractArns(attrs []saml.Attribute) (arns []ARN) {
 				// 1. arn:aws:iam::xxxxxxxxxxxx:role/MyRole,arn:aws:iam::xxxxxxxxxxxx:saml-provider/MyProvider
 				// 2. arn:aws:iam::xxxxxxxxxxxx:saml-provider/MyProvider,arn:aws:iam::xxxxxxxxxxxx:role/MyRole
 				// Error otherwise.
-				components := strings.Split(av.Value, ",")
+				components := strings.Split(strings.TrimSpace(av.Value), ",")
 				if len(components) != 2 {
 					// Wrong number of components - move on
 					continue


### PR DESCRIPTION
I had a few accounts where there was an extra space. The account worked fine on AWS but not on Clisso.

@johananl Do you think we need to trim the parts, too?