### PR TITLE
Okta Verify | conforming fo Okta Verify Push Factor

### DIFF
--- a/okta/client.go
+++ b/okta/client.go
@@ -97,6 +97,7 @@ type VerifyFactorResponse struct {
 	ExpiresAt    time.Time `json:"expiresAt"`
 	SessionToken string    `json:"sessionToken"`
 	Status       string    `json:"status"`
+	FactorResult string    `json:"factorResult,omitempty"`
 }
 
 // VerifyFactor performs MFA verification.

--- a/okta/client.go
+++ b/okta/client.go
@@ -45,6 +45,7 @@ type GetSessionTokenResponse struct {
 					Href string `json:"href"`
 				} `json:"verify"`
 			} `json:"_links"`
+			FactorType string `json:"factorType"`
 		} `json:"factors"`
 	} `json:"_embedded"`
 }

--- a/okta/get.go
+++ b/okta/get.go
@@ -78,6 +78,17 @@ func Get(app, provider string, duration int64) (*aws.Credentials, error) {
 			PassCode:   otp,
 			StateToken: resp.StateToken,
 		})
+
+		// for Okta Verify push notification: https://developer.okta.com/docs/api/resources/authn/#verify-push-factor
+		// "Keep polling authentication transactions with WAITING result until the challenge completes or expires."
+		for vfResp.FactorResult == "WAITING" {
+			vfResp, err = c.VerifyFactor(&VerifyFactorParams{
+				FactorID:   resp.Embedded.Factors[0].ID,
+				PassCode:   otp,
+				StateToken: resp.StateToken,
+			})
+		}
+
 		s.Stop()
 		if err != nil {
 			return nil, fmt.Errorf("verifying MFA: %v", err)

--- a/okta/get.go
+++ b/okta/get.go
@@ -3,6 +3,7 @@ package okta
 import (
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/allcloud-io/clisso/aws"
 	"github.com/allcloud-io/clisso/config"
@@ -10,6 +11,14 @@ import (
 	"github.com/allcloud-io/clisso/saml"
 	"github.com/allcloud-io/clisso/spinner"
 	"github.com/fatih/color"
+)
+
+const (
+	MFATypePush = "push"
+	MFATypeTOTP = "token:software:totp"
+
+	VerifyFactorStatusSuccess = "SUCCESS"
+	VerifyFactorStatusWaiting = "WAITING"
 )
 
 var (
@@ -63,35 +72,62 @@ func Get(app, provider string, duration int64) (*aws.Credentials, error) {
 	var st string
 
 	// TODO Handle multiple MFA devices (allow user to choose)
-	// TODO Verify MFA type?
 	switch resp.Status {
 	case StatusSuccess:
 		st = resp.SessionToken
 	case StatusMFARequired:
-		fmt.Print("Please enter the OTP from your MFA device: ")
-		var otp string
-		fmt.Scanln(&otp)
+		factor := resp.Embedded.Factors[0]
+		stateToken := resp.StateToken
 
-		s.Start()
-		vfResp, err := c.VerifyFactor(&VerifyFactorParams{
-			FactorID:   resp.Embedded.Factors[0].ID,
-			PassCode:   otp,
-			StateToken: resp.StateToken,
-		})
+		var vfResp *VerifyFactorResponse
 
-		// for Okta Verify push notification: https://developer.okta.com/docs/api/resources/authn/#verify-push-factor
-		// "Keep polling authentication transactions with WAITING result until the challenge completes or expires."
-		for vfResp.FactorResult == "WAITING" {
+		switch factor.FactorType {
+		case MFATypePush:
+			// Okta Verify push notification:
+			// https://developer.okta.com/docs/api/resources/authn/#verify-push-factor
+			// Keep polling authentication transactions with WAITING result until the challenge
+			// completes or expires.
+			fmt.Println("Please approve request on Okta Verify app")
+			s.Start()
 			vfResp, err = c.VerifyFactor(&VerifyFactorParams{
-				FactorID:   resp.Embedded.Factors[0].ID,
-				PassCode:   otp,
-				StateToken: resp.StateToken,
+				FactorID:   factor.ID,
+				StateToken: stateToken,
 			})
+			if err != nil {
+				return nil, fmt.Errorf("verifying MFA: %v", err)
+			}
+
+			for vfResp.FactorResult == VerifyFactorStatusWaiting {
+				vfResp, err = c.VerifyFactor(&VerifyFactorParams{
+					FactorID:   factor.ID,
+					StateToken: stateToken,
+				})
+				time.Sleep(2 * time.Second)
+			}
+			s.Stop()
+		case MFATypeTOTP:
+			fmt.Print("Please enter the OTP from your MFA device: ")
+			var otp string
+			fmt.Scanln(&otp)
+
+			s.Start()
+			vfResp, err = c.VerifyFactor(&VerifyFactorParams{
+				FactorID:   factor.ID,
+				PassCode:   otp,
+				StateToken: stateToken,
+			})
+			s.Stop()
+		default:
+			return nil, fmt.Errorf("unsupported MFA type '%s'", factor.FactorType)
 		}
 
-		s.Stop()
 		if err != nil {
 			return nil, fmt.Errorf("verifying MFA: %v", err)
+		}
+
+		// Handle failed MFA verification (verification rejected or timed out)
+		if vfResp.Status != VerifyFactorStatusSuccess {
+			return nil, fmt.Errorf("MFA verification failed")
 		}
 
 		st = vfResp.SessionToken


### PR DESCRIPTION
- this is needed for clisso to work with Okta Verify Push Factor method
- if FactorResult result in a response message is WAITING, we'll keep requests flowing
- this is documented here: https://developer.okta.com/docs/api/resources/authn/#verify-push-factor