### PR TITLE
[PR] remove nesting, align behavior

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -44,16 +44,17 @@ func WriteToFile(c *Credentials, filename string, section string) error {
 
 	// Remove expired credentials.
 	for _, s := range cfg.Sections() {
-		if s.HasKey(expireKey) {
-			v, err := s.Key(expireKey).TimeFormat(time.RFC3339)
-			if err != nil {
-				log.Printf(color.YellowString("Cannot parse date (%v) in section %s: %s"),
-					s.Key(expireKey), s.Name(), err)
-				continue
-			}
-			if time.Now().UTC().Unix() > v.Unix() {
-				cfg.DeleteSection(s.Name())
-			}
+		if !s.HasKey(expireKey) {
+			continue
+		}
+		v, err := s.Key(expireKey).TimeFormat(time.RFC3339)
+		if err != nil {
+			log.Printf(color.YellowString("Cannot parse date (%v) in section %s: %s"),
+				s.Key(expireKey), s.Name(), err)
+			continue
+		}
+		if time.Now().UTC().Unix() > v.Unix() {
+			cfg.DeleteSection(s.Name())
 		}
 	}
 
@@ -94,7 +95,6 @@ func GetValidCredentials(filename string) ([]Profile, error) {
 		if s.HasKey(expireKey) {
 			v, err := s.Key(expireKey).TimeFormat(time.RFC3339)
 			if err != nil {
-				// return nil, fmt.Errorf("%s key has invalid time format: %w", expireKey, err)
 				log.Printf(color.YellowString("Cannot parse date (%v) in section %s: %s"),
 						s.Key(expireKey), s.Name(), err)
 				continue

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -40,19 +40,19 @@ func WriteToFile(c *Credentials, filename string, section string) error {
 	cfg.Section(section).NewKey("aws_access_key_id", c.AccessKeyID)
 	cfg.Section(section).NewKey("aws_secret_access_key", c.SecretAccessKey)
 	cfg.Section(section).NewKey("aws_session_token", c.SessionToken)
-	cfg.Section(section).NewKey("aws_expiration", c.Expiration.UTC().Format(time.RFC3339))
+	cfg.Section(section).NewKey(expireKey, c.Expiration.UTC().Format(time.RFC3339))
 
 	// Remove expired credentials.
 	for _, s := range cfg.Sections() {
-		if s.HasKey("aws_expiration") {
-			v, err := s.Key("aws_expiration").TimeFormat(time.RFC3339)
-			if err == nil {
-				if time.Now().UTC().Unix() > v.Unix() {
-					cfg.DeleteSection(s.Name())
-				}
-			} else {
-				log.Printf(color.YellowString("Cannot parse date (%v) in section %s: %s",
-					s.Key("aws_expiration")), s.Name(), err)
+		if s.HasKey(expireKey) {
+			v, err := s.Key(expireKey).TimeFormat(time.RFC3339)
+			if err != nil {
+				log.Printf(color.YellowString("Cannot parse date (%v) in section %s: %s"),
+					s.Key(expireKey), s.Name(), err)
+				continue
+			}
+			if time.Now().UTC().Unix() > v.Unix() {
+				cfg.DeleteSection(s.Name())
 			}
 		}
 	}
@@ -94,7 +94,10 @@ func GetValidCredentials(filename string) ([]Profile, error) {
 		if s.HasKey(expireKey) {
 			v, err := s.Key(expireKey).TimeFormat(time.RFC3339)
 			if err != nil {
-				return nil, fmt.Errorf("%s key has invalid time format: %w", expireKey, err)
+				// return nil, fmt.Errorf("%s key has invalid time format: %w", expireKey, err)
+				log.Printf(color.YellowString("Cannot parse date (%v) in section %s: %s"),
+						s.Key(expireKey), s.Name(), err)
+				continue
 			}
 
 			if time.Now().UTC().Unix() < v.Unix() {


### PR DESCRIPTION
The behavior between WriteToFile (continue) and GetValidCredentials (error)
was not align. Now both cases will just print a warning.

Use the const `expireKey` consistently.

Less nesting due to handling the error first. This PR will fix #83.