### PR TITLE
Add support for preferred arn per app

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,8 @@ To create a OneLogin identity provider, use the following command:
         --subdomain mycompany \
         --username user@mycompany.com \
         --region US \
-        --duration 14400
+        --duration 14400 \
+        --arn arn:aws:iam::123456789012:role/Worker
 
 The example above creates a OneLogin identity provider configuration for Clisso, with the name
 `my-provider`.
@@ -166,6 +167,10 @@ duration, in seconds, instead of the default of 3600 (1 hour). Valid values are 
 the role in AWS. If a longer session time is requested than what is configured on the AWS role,
 Clisso will fallback to a duration of 3600. The default duration specified for the provider can be
 overridden on a per-app basis (see below).
+
+The `--arn` flag is optional. If specified, it will not prompt for a choice of roles presented
+from the list of available AWS accounts/roles. This makes it easy to run `clisso get my-app` 
+and get the correct account/role.
 
 #### Okta
 

--- a/cmd/apps.go
+++ b/cmd/apps.go
@@ -13,6 +13,7 @@ import (
 
 // Common
 var provider string
+var arn string
 var duration int
 
 // OneLogin
@@ -26,6 +27,7 @@ func init() {
 	cmdAppsCreateOneLogin.Flags().StringVar(&appID, "app-id", "", "OneLogin app ID")
 	cmdAppsCreateOneLogin.Flags().StringVar(&provider, "provider", "", "Name of the Clisso provider")
 	cmdAppsCreateOneLogin.Flags().IntVar(&duration, "duration", 0, "(Optional) Session duration in seconds")
+	cmdAppsCreateOneLogin.Flags().StringVar(&arn, "arn", "", "(Optional) preferred arn for app")
 	mandatoryFlag(cmdAppsCreateOneLogin, "app-id")
 	mandatoryFlag(cmdAppsCreateOneLogin, "provider")
 
@@ -118,6 +120,10 @@ var cmdAppsCreateOneLogin = &cobra.Command{
 		conf := map[string]string{
 			"app-id":   appID,
 			"provider": provider,
+		}
+
+		if arn != "" {
+			conf["arn"] = arn
 		}
 
 		if duration != 0 {

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -133,7 +133,7 @@ If no app is specified, the selected app (if configured) will be assumed.`,
 				log.Fatalf(color.RedString("Error processing credentials: %v"), err)
 			}
 		} else if pType == "okta" {
-			creds, err := okta.Get(app, provider, duration)
+			creds, err := okta.Get(app, provider, pArn, duration)
 			if err != nil {
 				log.Fatal(color.RedString("Could not get temporary credentials: "), err)
 			}

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -30,7 +30,7 @@ func init() {
 		"Write credentials to this file instead of the default ($HOME/.aws/credentials)",
 	)
 	err := viper.BindPFlag("global.credentials-path", cmdGet.Flags().Lookup("write-to-file"))
-	 if err != nil {
+	if err != nil {
 		log.Fatalf(color.RedString("Error binding flag global.credentials-path: %v"), err)
 	}
 }
@@ -116,10 +116,14 @@ If no app is specified, the selected app (if configured) will be assumed.`,
 			log.Fatalf(color.RedString("Could not get provider type for provider '%s'"), provider)
 		}
 
+		// allow preferred "arn" to be specified in the config file for each app
+		// if this is not specified the value will be empty ("")
+		pArn := viper.GetString(fmt.Sprintf("apps.%s.arn", app))
+
 		duration := sessionDuration(app, provider)
 
 		if pType == "onelogin" {
-			creds, err := onelogin.Get(app, provider, duration)
+			creds, err := onelogin.Get(app, provider, pArn, duration)
 			if err != nil {
 				log.Fatal(color.RedString("Could not get temporary credentials: "), err)
 			}

--- a/okta/get.go
+++ b/okta/get.go
@@ -26,7 +26,7 @@ var (
 )
 
 // Get gets temporary credentials for the given app.
-func Get(app, provider string, duration int64) (*aws.Credentials, error) {
+func Get(app, provider, pArn string, duration int64) (*aws.Credentials, error) {
 	// Get provider config
 	p, err := config.GetOktaProvider(provider)
 	if err != nil {
@@ -146,8 +146,7 @@ func Get(app, provider string, duration int64) (*aws.Credentials, error) {
 		return nil, fmt.Errorf("Error launching app: %v", err)
 	}
 
-	// Passing in "" to the saml.Get since okta does not support the pArn value (yet)
-	arn, err := saml.Get(*samlAssertion, "")
+	arn, err := saml.Get(*samlAssertion, pArn)
 	if err != nil {
 		return nil, err
 	}

--- a/okta/get.go
+++ b/okta/get.go
@@ -146,7 +146,8 @@ func Get(app, provider string, duration int64) (*aws.Credentials, error) {
 		return nil, fmt.Errorf("Error launching app: %v", err)
 	}
 
-	arn, err := saml.Get(*samlAssertion)
+	// Passing in "" to the saml.Get since okta does not support the pArn value (yet)
+	arn, err := saml.Get(*samlAssertion, "")
 	if err != nil {
 		return nil, err
 	}

--- a/onelogin/get.go
+++ b/onelogin/get.go
@@ -35,7 +35,7 @@ var (
 
 // Get gets temporary credentials for the given app.
 // TODO Move AWS logic outside this function.
-func Get(app, provider string, duration int64) (*aws.Credentials, error) {
+func Get(app, provider, pArn string, duration int64) (*aws.Credentials, error) {
 	// Read config
 	p, err := config.GetOneLoginProvider(provider)
 	if err != nil {
@@ -175,7 +175,7 @@ func Get(app, provider string, duration int64) (*aws.Credentials, error) {
 		rData = rSaml.Data
 	}
 
-	arn, err := saml.Get(rData)
+	arn, err := saml.Get(rData, pArn)
 	if err != nil {
 		return nil, err
 	}

--- a/saml/saml_test.go
+++ b/saml/saml_test.go
@@ -59,7 +59,7 @@ func TestGet(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			b, _ := ioutil.ReadFile(test.path)
 
-			arn, err := Get(string(b))
+			arn, err := Get(string(b), "")
 			if test.expectError && err == nil {
 				t.Errorf("expected error")
 			}

--- a/sample_config.yaml
+++ b/sample_config.yaml
@@ -4,6 +4,7 @@ apps:
     principal-arn: arn:aws:iam::123456789012:saml-provider/OneLoginDev
     provider: sample-onelogin-provider
     role-arn: arn:aws:iam::123456789012:role/OneLoginDev-SSO
+    arn: arn:aws:iam::012345678012:role/Dev
   sample-app-2:
     principal-arn: arn:aws:iam::123456789012:saml-provider/Okta
     provider: sample-okta-provider


### PR DESCRIPTION
Adding support for specifying an arn to use per "app" so that you don't have to always choose from the list.

Configuration change to `clisso.yaml`:
```
apps:
  prod:
    app-id: "123456"
    principal-arn: arn:aws:iam::XXXXXXXXXXXX:policy/OneLoginListRoles
    provider: onelogin-provider
    role-arn: arn:aws:iam::XXXXXXXXXXXX:saml-provider/OneLogin
    duration: 28800
    arn: arn:aws:iam::XXXXXXXXXXXX:role/SRE
```