### PR TITLE
Fix session duration mismatch

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,16 +24,16 @@ builds:
       - darwin
     goarch:
       - "amd64"
-    hooks:
-      post: gon gon-amd64.json
+    # hooks:
+    #   post: gon gon-amd64.json
   - id: macos-arm64
     binary: clisso
     goos:
       - darwin
     goarch:
       - "arm64"
-    hooks:
-      post: gon gon-arm64.json
+    # hooks:
+    #   post: gon gon-arm64.json
 
 archives:
   - format: zip

--- a/aws/sts.go
+++ b/aws/sts.go
@@ -45,7 +45,7 @@ func AssumeSAMLRole(PrincipalArn, RoleArn, SAMLAssertion, awsRegion string, dura
 		var ae smithy.APIError
 		if errors.As(err, &ae) {
 			// Check if error indicates exceeded duration, no structured error exists so check error message content.
-			if strings.Contains(ae.ErrorMessage(), "'durationSeconds' failed to satisfy constraint") {
+			if strings.Contains(ae.ErrorMessage(), "'durationSeconds' failed to satisfy constraint") || ae.ErrorMessage() == ErrInvalidSessionDuration {
 				// Return a custom error to allow the caller to retry etc.
 				// TODO Return a custom error type instead of a special value:
 				// https://dave.cheney.net/2014/12/24/inspecting-errors


### PR DESCRIPTION
#283 removed catching the requested duration being bigger than configured duration by accident. This MR adds it back