### PR TITLE
Add default MFA device selection for OneLogin

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ To use a regional endpoint, specify the region via the `global.aws-region` field
 
 ## YubiKey Autodetection
 
-YubiKey Autodetection is available for the OneLogin provider. To enable this feature set the `global.autodetect-yubikey` field to `true`. A per app configuration using `apps.<app>.autodetect-yubikey` is also available. Clisso will look at attached USB devices and automatically select the YubiKey as an MFA device if it is available. 
+YubiKey Autodetection is available for the OneLogin provider. To enable this feature set the `global.autodetect-yubikey` field to `true`. Clisso will look at attached USB devices and automatically select the YubiKey as an MFA device if it is available. 
 
 ## Caveats and Limitations
 

--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ To save the credentials to a custom file, use the `--output` flag with a custom 
 To print the credentials to the shell instead of storing them in a file, use the `--output environment` flag. This
 will output shell commands which can be pasted in any shell to use the credentials.
 
-To select a specific MFA device by name instead of choosing from a list, use the `-m` flag. The 
+To select a specific MFA device by name instead of choosing from a list, use the `-m` flag. The
 configuration field `global.mfa-device` may also be set.
 
 ### Running as `credential_process`
@@ -390,7 +390,7 @@ YubiKey Autodetection is available for the OneLogin provider. To enable this fea
 ## Caveats and Limitations
 
 - No support for Okta applications with MFA enabled **at the application level**.
-- Yubikey Autodetection is only available on select platforms:
+- Yubikey Autodetection is only available with the prebuilt binaries on these platforms:
   - MacOS (ARM/x86)
   - Linux (x86)
   - Windows (x86)

--- a/README.md
+++ b/README.md
@@ -373,6 +373,10 @@ AWS recommends using [regional STS endpoints](https://docs.aws.amazon.com/sdkref
 
 To use a regional endpoint, specify the region via the `global.aws-region` field in the config file. A per app configuration using `apps.<app>.aws-region` is also possible.
 
+## YubiKey Autodetection
+
+YubiKey Autodetection is available for the OneLogin provider. To enable this feature set the `global.autodetect-yubikey` field to `true`. A per app configuration using `apps.<app>.autodetect-yubikey` is also available. Clisso will look at attached USB devices and automatically select the YubiKey as an MFA device if it is available. 
+
 ## Caveats and Limitations
 
 - No support for Okta applications with MFA enabled **at the application level**.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ go install
 go clean
 ```
 
+#### MacOS Signing
+
+A [self-signed certificate](https://support.apple.com/guide/keychain-access/create-self-signed-certificates-kyca8916/mac) may be created and used to sign the binary when building Clisso from source on a MacOS machine with Gatekeeper enabled. After installing Clisso, sign the binary:
+
+```
+codesign -f -s "Your Certificate Name" $GOPATH/bin/clisso
+```
+
 ## Configuration
 
 Clisso stores configuration in a file called `.clisso.yaml` under the user's home directory. You
@@ -377,11 +385,15 @@ To use a regional endpoint, specify the region via the `global.aws-region` field
 
 ## YubiKey Autodetection
 
-YubiKey Autodetection is available for the OneLogin provider. To enable this feature set the `global.autodetect-yubikey` field to `true`. Clisso will look at attached USB devices and automatically select the YubiKey as an MFA device if it is available. 
+YubiKey Autodetection is available for the OneLogin provider. To enable this feature set the `global.autodetect-yubikey` field to `true`. Clisso will look at attached USB devices and automatically select the YubiKey as an MFA device if it is available. Only one YubiKey may be connected for this feature to work.
 
 ## Caveats and Limitations
 
 - No support for Okta applications with MFA enabled **at the application level**.
+- Yubikey Autodetection is only available on select platforms:
+  - MacOS (ARM/x86)
+  - Linux (x86)
+  - Windows (x86)
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -296,6 +296,9 @@ To save the credentials to a custom file, use the `--output` flag with a custom 
 To print the credentials to the shell instead of storing them in a file, use the `--output environment` flag. This
 will output shell commands which can be pasted in any shell to use the credentials.
 
+To select a specific MFA device by name instead of choosing from a list, use the `-m` flag. The 
+configuration field `global.mfa-device` may also be set.
+
 ### Running as `credential_process`
 
 AWS CLI v2 introduced the `credential_process` feature which allows you to use an external command to obtain temporal credentials.
@@ -346,7 +349,6 @@ clisso cp status # to check the status
 If you disable the `credential_process` functionality, all refreshes will be disabled. While cached credentials will still be used, new credentials will not be fetched. This can be useful if you lock your computer with an active, e.g., VSCode session with CodeCommit. If you wouldn't disable the `credential_process` functionality, the VSCode would constantly trigger new credential requests to refresh the remote CodeCommit repository.
 
 If you want to check the status programmatically, you can use the exit code of the `clisso cp status` command. If the exit code is `0`, the `credential_process` functionality is enabled. If the exit code is `1`, the `credential_process` functionality is disabled.
-
 
 ### Storing the password in the key chain
 

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -30,9 +30,10 @@ var cacheCredentials bool
 var writeToFile string
 var cacheToFile string
 var lock lockfile.Lockfile
+var mfaDevice string
 
 const defaultOutput = "~/.aws/credentials"
-var mfaDevice string
+
 
 func init() {
 

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -32,6 +32,7 @@ var cacheToFile string
 var lock lockfile.Lockfile
 
 const defaultOutput = "~/.aws/credentials"
+var mfaDevice string
 
 func init() {
 
@@ -89,6 +90,15 @@ func setOutput(cmd *cobra.Command, app string) {
 		printToCredentialProcess = true
 	default:
 		writeToFile = o
+	}
+	cmdGet.Flags().StringVarP(
+		&mfaDevice, "mfa-device", "m", "",
+		"Specify an MFA device to use (OneLogin Only)",
+	)
+	// Bind mfa-device to viper so it can be easily accessed.
+	err = viper.BindPFlag("global.mfa-device", cmdGet.Flags().Lookup("mfa-device"))
+	if err != nil {
+		log.Fatalf("Error binding flag global.mfa-device: %v", err)
 	}
 }
 

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -34,7 +34,6 @@ var mfaDevice string
 
 const defaultOutput = "~/.aws/credentials"
 
-
 func init() {
 
 	RootCmd.AddCommand(cmdGet)

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -74,6 +74,16 @@ func init() {
 
 	cmdGet.MarkFlagsMutuallyExclusive("output", "shell", "write-to-file")
 
+	cmdGet.Flags().StringVarP(
+		&mfaDevice, "mfa-device", "m", "",
+		"Specify an MFA device to use (OneLogin Only)",
+	)
+	// Bind mfa-device to viper so it can be easily accessed.
+	err = viper.BindPFlag("global.mfa-device", cmdGet.Flags().Lookup("mfa-device"))
+	if err != nil {
+		log.Fatalf("Error binding flag global.mfa-device: %v", err)
+	}
+
 	lock, err = lockfile.New(filepath.Join(os.TempDir(), "clisso.lock"))
 	if err != nil {
 		log.Fatalf("Failed to create lock: %v", err)
@@ -91,15 +101,6 @@ func setOutput(cmd *cobra.Command, app string) {
 		printToCredentialProcess = true
 	default:
 		writeToFile = o
-	}
-	cmdGet.Flags().StringVarP(
-		&mfaDevice, "mfa-device", "m", "",
-		"Specify an MFA device to use (OneLogin Only)",
-	)
-	// Bind mfa-device to viper so it can be easily accessed.
-	err = viper.BindPFlag("global.mfa-device", cmdGet.Flags().Lookup("mfa-device"))
-	if err != nil {
-		log.Fatalf("Error binding flag global.mfa-device: %v", err)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/rifflock/lfshook v0.0.0-20180920164130-b9218ef580f5
 	github.com/sirupsen/logrus v1.9.3
-<<<<<<< HEAD
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.19.0
@@ -26,14 +25,6 @@ require (
 	github.com/zalando/go-keyring v0.2.6
 	golang.org/x/net v0.31.0
 	golang.org/x/term v0.26.0
-=======
-	github.com/spf13/cobra v1.8.0
-	github.com/spf13/viper v1.17.0
-	github.com/stretchr/testify v1.8.4
-	github.com/zalando/go-keyring v0.2.3
-	golang.org/x/net v0.19.0
-	golang.org/x/term v0.15.0
->>>>>>> 2af92c5 (add mfa-device flag)
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/rifflock/lfshook v0.0.0-20180920164130-b9218ef580f5
 	github.com/sirupsen/logrus v1.9.3
+<<<<<<< HEAD
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.19.0
@@ -25,6 +26,14 @@ require (
 	github.com/zalando/go-keyring v0.2.6
 	golang.org/x/net v0.31.0
 	golang.org/x/term v0.26.0
+=======
+	github.com/spf13/cobra v1.8.0
+	github.com/spf13/viper v1.17.0
+	github.com/stretchr/testify v1.8.4
+	github.com/zalando/go-keyring v0.2.3
+	golang.org/x/net v0.19.0
+	golang.org/x/term v0.15.0
+>>>>>>> 2af92c5 (add mfa-device flag)
 )
 
 require (
@@ -35,7 +44,11 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.4 // indirect
 	github.com/beevik/etree v1.2.0 // indirect
+<<<<<<< HEAD
 	github.com/danieljoos/wincred v1.2.2 // indirect
+=======
+	github.com/danieljoos/wincred v1.2.0 // indirect
+>>>>>>> 2af92c5 (add mfa-device flag)
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fatih/color v1.14.1 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
@@ -48,7 +61,11 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
+<<<<<<< HEAD
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
+=======
+	github.com/pelletier/go-toml/v2 v2.1.0 // indirect
+>>>>>>> 2af92c5 (add mfa-device flag)
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
 	github.com/russellhaering/goxmldsig v1.4.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/allcloud-io/clisso
 
-go 1.23
+go 1.23.0
 
 require (
 	github.com/PuerkitoBio/goquery v1.10.0
@@ -11,6 +11,7 @@ require (
 	github.com/crewjam/saml v0.4.14
 	github.com/go-ini/ini v1.67.0
 	github.com/icza/gog v0.0.0-20230509085756-00e776132a34
+	github.com/karalabe/hid v1.0.0
 	github.com/mattn/go-colorable v0.1.13
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/nightlyone/lockfile v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -35,11 +35,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.4 // indirect
 	github.com/beevik/etree v1.2.0 // indirect
-<<<<<<< HEAD
 	github.com/danieljoos/wincred v1.2.2 // indirect
-=======
-	github.com/danieljoos/wincred v1.2.0 // indirect
->>>>>>> 2af92c5 (add mfa-device flag)
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fatih/color v1.14.1 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
@@ -52,11 +48,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
-<<<<<<< HEAD
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
-=======
-	github.com/pelletier/go-toml/v2 v2.1.0 // indirect
->>>>>>> 2af92c5 (add mfa-device flag)
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
 	github.com/russellhaering/goxmldsig v1.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,8 @@ github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLf
 github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
 github.com/jonboulle/clockwork v0.4.0 h1:p4Cf1aMWXnXAUh8lVfewRBx1zaTSYKrKMF2g3ST4RZ4=
 github.com/jonboulle/clockwork v0.4.0/go.mod h1:xgRqUGwRcjKCO1vbZUEtSLrqKoPSsUpK7fnezOII0kc=
+github.com/karalabe/hid v1.0.0 h1:+/CIMNXhSU/zIJgnIvBD2nKHxS/bnRHhhs9xBryLpPo=
+github.com/karalabe/hid v1.0.0/go.mod h1:Vr51f8rUOLYrfrWDFlV12GGQgM5AT8sVh+2fY4MPeu8=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=

--- a/onelogin/get.go
+++ b/onelogin/get.go
@@ -314,7 +314,7 @@ func getDevice(devices []Device, opts *DeviceOptions) (device *Device, err error
 			if d.DeviceType == opts.MfaDevice {
 				device = &d
 				log.WithFields(log.Fields{
-					"MfaDevice":      opts.MfaDevice,
+					"MfaDevice": opts.MfaDevice,
 				}).Trace("MFA device found, automatically selecting it.")
 				return
 			}

--- a/onelogin/get.go
+++ b/onelogin/get.go
@@ -22,7 +22,6 @@ import (
 	"github.com/allcloud-io/clisso/yubikey"
 	"github.com/icza/gog"
 	"github.com/spf13/viper"
-
 )
 
 const (
@@ -46,7 +45,45 @@ var (
 )
 
 type DeviceOptions struct {
+	// Detect if a YubiKey is inserted and automatically select the device
 	AutodetectYubiKey bool
+
+	// Override all other choices and select this device name if available
+	MfaDevice string
+}
+
+// NewDeviceOptions returns a configured pointer to a DeviceOptions type
+func NewDeviceOptions() *DeviceOptions {
+	d := new(DeviceOptions)
+	d.setAutodetectYubiKey()
+	d.setMfaDevice()
+
+	log.WithFields(log.Fields{
+		"autodetectYubiKey": d.AutodetectYubiKey,
+		"MfaDevice":         d.MfaDevice,
+	}).Debug("created device options configuration")
+
+	return d
+}
+
+// setAutodetectYubiKey sets the AutodetectYubiKey parameter
+func (d *DeviceOptions) setAutodetectYubiKey() {
+	var a bool
+	if viper.IsSet("global.autodetect-yubikey") {
+		a = viper.GetBool("global.autodetect-yubikey")
+	}
+	if a && yubikey.IsAttached() {
+		d.AutodetectYubiKey = true
+		return
+	}
+}
+
+// setMfaDevice sets the MfaDevice parameter based on user input
+func (d *DeviceOptions) setMfaDevice() {
+	if viper.IsSet("global.mfa-device") {
+		d.MfaDevice = viper.GetString("global.mfa-device")
+		return
+	}
 }
 
 // Get gets temporary credentials for the given app.
@@ -139,9 +176,7 @@ func Get(app, provider, pArn, awsRegion string, duration int32, interactive bool
 		devices := rSaml.Devices
 		log.WithField("Devices", devices).Trace("Devices returned by GenerateSamlAssertion")
 
-		deviceOpts := DeviceOptions{
-			AutodetectYubiKey: autodetectYubiKey(app),
-		}
+		deviceOpts := NewDeviceOptions()
 
 		device, err := getDevice(devices, deviceOpts)
 		if err != nil {
@@ -261,7 +296,7 @@ func Get(app, provider, pArn, awsRegion string, duration int32, interactive bool
 
 // getDevice gets a slice of MFA devices, prompts the user to select one and returns the selected device.
 // If the slice contains only a single device, that device is returned. If the slice is empty, an error is returned.
-func getDevice(devices []Device, opts DeviceOptions) (device *Device, err error) {
+func getDevice(devices []Device, opts *DeviceOptions) (device *Device, err error) {
 	if len(devices) == 0 {
 		// This should never happen
 		err = errors.New("no MFA device returned by Onelogin")
@@ -274,7 +309,19 @@ func getDevice(devices []Device, opts DeviceOptions) (device *Device, err error)
 		return
 	}
 
-	if opts.AutodetectYubiKey && yubikey.IsAttached(){
+	if opts.MfaDevice != "" {
+		for _, d := range devices {
+			if d.DeviceType == opts.MfaDevice {
+				device = &d
+				fmt.Printf("MFA device %s found, automatically selecting it.\n", opts.MfaDevice)
+				return
+			}
+		}
+		// If the user requested device is not found, fall through and continue the device selection process.
+		fmt.Printf("MFA device %s not found.\n", opts.MfaDevice)
+	}
+
+	if opts.AutodetectYubiKey {
 		for _, d := range devices {
 			if d.DeviceType == MFADeviceYubicoYubiKey {
 				device = &d
@@ -314,16 +361,4 @@ func getDevice(devices []Device, opts DeviceOptions) (device *Device, err error)
 	}
 	device = &Device{DeviceID: devices[selection-1].DeviceID, DeviceType: devices[selection-1].DeviceType}
 	return
-}
-
-// autodetectYubiKey returns a bool if YubiKey Autodetection should be used
-func autodetectYubiKey(app string) bool {
-	y := fmt.Sprintf("apps.%s.autodetect-yubikey", app)
-	if viper.IsSet(y) {
-		return viper.GetBool(y)
-	}
-	if viper.IsSet("global.autodetect-yubikey") {
-		return viper.GetBool("global.autodetect-yubikey")
-	}
-	return false
 }

--- a/onelogin/get.go
+++ b/onelogin/get.go
@@ -313,7 +313,9 @@ func getDevice(devices []Device, opts *DeviceOptions) (device *Device, err error
 		for _, d := range devices {
 			if d.DeviceType == opts.MfaDevice {
 				device = &d
-				fmt.Printf("MFA device %s found, automatically selecting it.\n", opts.MfaDevice)
+				log.WithFields(log.Fields{
+					"MfaDevice":      opts.MfaDevice,
+				}).Trace("MFA device found, automatically selecting it.")
 				return
 			}
 		}
@@ -325,7 +327,7 @@ func getDevice(devices []Device, opts *DeviceOptions) (device *Device, err error
 		for _, d := range devices {
 			if d.DeviceType == MFADeviceYubicoYubiKey {
 				device = &d
-				fmt.Println("YubiKey detected, automatically selecting it.")
+				log.Trace("YubiKey detected, automatically selecting it as MFA device.")
 				return
 			}
 		}

--- a/onelogin/get_test.go
+++ b/onelogin/get_test.go
@@ -1,0 +1,77 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+package onelogin
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetDevice(t *testing.T) {
+
+	var deviceList = []Device{
+		{
+			DeviceID:   01,
+			DeviceType: "Yubico YubiKey",
+		},
+		{
+			DeviceID:   02,
+			DeviceType: "OneLogin Protect",
+		},
+		{
+			DeviceID:   03,
+			DeviceType: "Google Authenticator",
+		},
+	}
+
+	cases := []struct {
+		Name           string
+		Devices        []Device
+		Opts           *DeviceOptions
+		ExpectedDevice *Device
+		ExpectedError  error
+	}{
+		{
+			Name:           "NoDevices",
+			Devices:        []Device{},
+			Opts:           &DeviceOptions{},
+			ExpectedDevice: nil,
+			ExpectedError:  errors.New("no MFA device returned by Onelogin"),
+		},
+		{
+			Name:           "AutodetectYubiKey",
+			Devices:        deviceList,
+			Opts:           &DeviceOptions{AutodetectYubiKey: true},
+			ExpectedDevice: &Device{DeviceID: 01, DeviceType: "Yubico YubiKey"},
+			ExpectedError:  nil,
+		},
+		{
+			Name:           "SelectedMfaDevice",
+			Devices:        deviceList,
+			Opts:           &DeviceOptions{MfaDevice: "Google Authenticator"},
+			ExpectedDevice: &Device{DeviceID: 03, DeviceType: "Google Authenticator"},
+			ExpectedError:  nil,
+		},
+		{
+			Name:           "SelectedMfaDeviceOverride",
+			Devices:        deviceList,
+			Opts:           &DeviceOptions{AutodetectYubiKey: true, MfaDevice: "Google Authenticator"},
+			ExpectedDevice: &Device{DeviceID: 03, DeviceType: "Google Authenticator"},
+			ExpectedError:  nil,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+
+			d, err := getDevice(c.Devices, c.Opts)
+			assert.Equal(t, c.ExpectedDevice, d)
+			assert.Equal(t, c.ExpectedError, err)
+		})
+	}
+}

--- a/sample_config.yaml
+++ b/sample_config.yaml
@@ -6,7 +6,6 @@ apps:
     role-arn: arn:aws:iam::123456789012:role/OneLoginDev-SSO
     arn: arn:aws:iam::012345678012:role/Dev
     aws-region: eu-west-1
-    autodetect-yubikey: true
   sample-app-2:
     principal-arn: arn:aws:iam::123456789012:saml-provider/Okta
     provider: sample-okta-provider

--- a/sample_config.yaml
+++ b/sample_config.yaml
@@ -6,12 +6,14 @@ apps:
     role-arn: arn:aws:iam::123456789012:role/OneLoginDev-SSO
     arn: arn:aws:iam::012345678012:role/Dev
     aws-region: eu-west-1
+    autodetect-yubikey: true
   sample-app-2:
     principal-arn: arn:aws:iam::123456789012:saml-provider/Okta
     provider: sample-okta-provider
     role-arn: arn:aws:iam::123456789012:role/OktaDevSSO
     url: https://xxxxxxxx.oktapreview.com/home/amazon_aws/xxxxxxxxxxxxxxxxxxxx/137
 global:
+  autodetect-yubikey: true
   aws-region: us-east-1
   output: ~/.aws/credentials
   selected-app: sample-app-1

--- a/yubikey/yubikey.go
+++ b/yubikey/yubikey.go
@@ -2,7 +2,7 @@ package yubikey
 
 import (
 	"github.com/karalabe/hid"
-	log "github.com/sirupsen/logrus"
+	"github.com/allcloud-io/clisso/log"
 )
 
 // USB Vendor ID is a permanent ID issued by USB Implementers Forum 

--- a/yubikey/yubikey.go
+++ b/yubikey/yubikey.go
@@ -1,0 +1,31 @@
+package yubikey
+
+import (
+	"github.com/karalabe/hid"
+	log "github.com/sirupsen/logrus"
+)
+
+// IsAttached queries the connected USB devices and returns true if a YubiKey is attached
+func IsAttached() bool {
+	var yubiKeyVendorID uint16 = 0x1050
+
+	// List all USB devices matching the YubiKey vendor ID
+	devices := hid.Enumerate(yubiKeyVendorID, 0)
+
+	if len(devices) == 0 {
+		log.Debug("No YubiKey device detected")
+		return false
+	}
+
+	// Log information about the detected YubiKey(s)
+	if log.GetLevel() == log.DebugLevel {
+		for _, device := range devices {
+			log.WithFields(log.Fields{
+				"vid":     device.VendorID,
+				"pid":     device.ProductID,
+				"product": device.Product,
+			}).Debug("YubiKey device detected")
+		}
+	}
+	return true
+}

--- a/yubikey/yubikey.go
+++ b/yubikey/yubikey.go
@@ -5,9 +5,11 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// USB Vendor ID is a permanent ID issued by USB Implementers Forum 
+const yubiKeyVendorID uint16 = 0x1050
+
 // IsAttached queries the connected USB devices and returns true if a YubiKey is attached
 func IsAttached() bool {
-	var yubiKeyVendorID uint16 = 0x1050
 
 	// List all USB devices matching the YubiKey vendor ID
 	devices := hid.Enumerate(yubiKeyVendorID, 0)

--- a/yubikey/yubikey.go
+++ b/yubikey/yubikey.go
@@ -1,11 +1,11 @@
 package yubikey
 
 import (
-	"github.com/karalabe/hid"
 	"github.com/allcloud-io/clisso/log"
+	"github.com/karalabe/hid"
 )
 
-// USB Vendor ID is a permanent ID issued by USB Implementers Forum 
+// USB Vendor ID is a permanent ID issued by USB Implementers Forum
 const yubiKeyVendorID uint16 = 0x1050
 
 // IsAttached queries the connected USB devices and returns true if a YubiKey is attached


### PR DESCRIPTION
This PR adds support for a default MFA device with OneLogin, saving the user the trouble of the single keystroke to select their MFA device from a list. 

There are two primary features:
1. A new `--mfa-device` flag and global option. This flag matches the device name returned from OneLogin. 
2. YubiKey Autodetection. If a YubiKey is connected to the machine executing Clisso, it will automatically be selected as the MFA device to use.

The YubiKey autodetection relies on the karalabe/hid package which needs CGO enabled and appropriate C toolchain installed in order to cross compile. I did not make these changes to .goreleaser as I'm not sure exactly how the build machine is setup and what toolchains are available to use. I'm happy to make any requested changes, but am asking for a little guidance here. Opening as a Draft until the .goreleaser issue is resolved.