### PR TITLE
Showing correct answer for Okta Verify during unusual login attempts

### DIFF
--- a/okta/client.go
+++ b/okta/client.go
@@ -105,6 +105,15 @@ type VerifyFactorResponse struct {
 	SessionToken string    `json:"sessionToken"`
 	Status       string    `json:"status"`
 	FactorResult string    `json:"factorResult,omitempty"`
+	Embedded     struct {
+		Factor struct {
+			Embedded struct {
+				Challenge struct {
+					CorrectAnswer int `json:"correctAnswer"`
+				} `json:"challenge"`
+			} `json:"_embedded"`
+		} `json:"factor"`
+	} `json:"_embedded"`
 }
 
 // VerifyFactor performs MFA verification.

--- a/okta/get.go
+++ b/okta/get.go
@@ -124,8 +124,8 @@ func Get(app, provider, pArn, awsRegion string, duration int32) (*aws.Credential
 				return nil, fmt.Errorf("verifying MFA: %v", err)
 			}
 
-            // true if correct answer for Okta Verify has already been shown in CLI
-            // to avoid spamming the user
+			// true if correct answer for Okta Verify has already been shown in CLI
+			// to avoid spamming the user
 			var answerShown bool
 
 			for vfResp.FactorResult == VerifyFactorStatusWaiting {
@@ -134,7 +134,9 @@ func Get(app, provider, pArn, awsRegion string, duration int32) (*aws.Credential
 					StateToken: stateToken,
 				})
 				if answer := vfResp.Embedded.Factor.Embedded.Challenge.CorrectAnswer; answer != 0 && !answerShown {
-					fmt.Printf("Okta marked the attempt as unusual, select number %d in Okta Verify", answer)
+					s.Stop()
+					fmt.Printf("Okta marked the attempt as unusual, select number '%d' in Okta Verify\n", answer)
+					answerShown = true
 				}
 				time.Sleep(2 * time.Second)
 			}


### PR DESCRIPTION
Hello there,

I stumbled upon an issue: Okta can mark login attempt as unusual, requiring to select one of three numbers in Okta Verify. Clisso currently doesn't support it, leading user to guessing which number is correct. 

I've resolved the issue within this PR, but the spinner keeps clearing terminal's content - so the message with correct number is visible very briefly and then gets cleared out. 