### PR TITLE
check for nil response. update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,13 +60,13 @@ git clone github.com/allcloud-io/clisso
 
 # Build the binary
 cd clisso
-make
+go build
 
 # Install the binary in $GOPATH/bin
-make install
+go install
 
 # Clean up
-make clean
+go clean
 ```
 
 ## Configuration

--- a/onelogin/client.go
+++ b/onelogin/client.go
@@ -113,13 +113,18 @@ func makeRequest(method string, url string, headers map[string]string, body inte
 // using the client, handles any HTTP-related errors and returns any data as a string.
 func (c *Client) doRequest(r *http.Request) (string, error) {
 	resp, err := c.Do(r)
-	log.WithFields(log.Fields{
-		"status": resp.Status,
-		"url":    resp.Request.URL,
-		"host":   resp.Request.Host,
-		"code":   resp.StatusCode,
-		"method": resp.Request.Method,
-	}).WithError(err).Trace("HTTP request sent")
+
+	if resp != nil {
+		log.WithFields(
+			log.Fields{
+				"status": resp.Status,
+				"url":    resp.Request.URL,
+				"host":   resp.Request.Host,
+				"code":   resp.StatusCode,
+				"method": resp.Request.Method,
+			}).WithError(err).Trace("HTTP request sent")
+	}
+
 	if err != nil {
 		return "", fmt.Errorf("sending HTTP request: %v", err)
 	}


### PR DESCRIPTION
Fix for 
`⠋panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x157bc74]
`

when an http proxy is set. Or for whatever reason a response is not returned by the http client. 

Update README. 