### PR TITLE
protect profiles with settings

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -85,7 +85,7 @@ func init() {
 	// }
 
 	RootCmd.PersistentFlags().StringVarP(
-		&logFile, "log-file", "", "~/.clisso.log", "log file location",
+		&logFile, "log-file", "", "", "log file location",
 	)
 	// err = viper.BindPFlag("global.log.file", RootCmd.PersistentFlags().Lookup("log-file"))
 	// if err != nil {


### PR DESCRIPTION
Avoid config loss by checking if the profile should be overwritten.

If profiles contain configuration, they were bluntly overwritten by Clisso.
Now, Clisso preserves the config for compatible options. It errors out for incompatible options like `credentials_process`.

Additionally, this restores the StdErr logging behavior described in the README.